### PR TITLE
Common JS and ESM support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
         "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -2,26 +2,23 @@
   "name": "shinami",
   "version": "0.1.0",
   "description": "TypeScript SDK for Shinami services",
-  "type": "module",
-  "main": "./dist/cjs/index.js",
-  "types": "./dist/esm/index.d.ts",
   "engines": {
     "node": ">=14"
   },
   "files": [
-    "dist/cjs",
-    "dist/esm"
+    "dist"
   ],
   "exports": {
     ".": {
-      "import": "./dist/esm/src/index.js",
-      "require": "./dist/cjs/src/index.js"
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
     }
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:esm",
+    "build": "npm run build:cjs && npm run build:esm && npm run build:patch",
     "build:cjs": "tsc --build tsconfig.cjs.json",
     "build:esm": "tsc --build tsconfig.esm.json",
+    "build:patch": "./patch-build.sh",
     "lint": "eslint .",
     "clean": "rm -fr ./dist ./coverage",
     "test": "jest unit",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,25 @@
   "version": "0.1.0",
   "description": "TypeScript SDK for Shinami services",
   "type": "module",
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "types": "./dist/esm/index.d.ts",
   "engines": {
     "node": ">=14"
   },
   "files": [
-    "./dist"
+    "dist/cjs",
+    "dist/esm"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js"
+    }
+  },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc --build tsconfig.cjs.json",
+    "build:esm": "tsc --build tsconfig.esm.json",
     "lint": "eslint .",
     "clean": "rm -fr ./dist ./coverage",
     "test": "jest unit",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     }
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:esm && npm run build:patch",
-    "build:cjs": "tsc --build tsconfig.cjs.json",
-    "build:esm": "tsc --build tsconfig.esm.json",
-    "build:patch": "./patch-build.sh",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc --build tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
+    "build:esm": "tsc --build tsconfig.esm.json && echo '{\"type\":\"module\"}' > dist/esm/package.json",
     "lint": "eslint .",
     "clean": "rm -fr ./dist ./coverage",
     "test": "jest unit",

--- a/patch-build.sh
+++ b/patch-build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+
+echo '{"type":"module"}' > dist/esm/package.json
+echo '{"type":"commonjs"}' > dist/cjs/package.json

--- a/patch-build.sh
+++ b/patch-build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo '{"type":"module"}' > dist/esm/package.json
-echo '{"type":"commonjs"}' > dist/cjs/package.json

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/cjs",
+    "target": "ESNext",
+    "module": "CommonJS",
+    "noEmitHelpers": false
+  },
+}

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
+    "module": "commonjs",
     
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,8 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "target": "ESNext",
-    "module": "CommonJS",
-    "noEmitHelpers": false
-  },
+    
+  }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,7 +2,5 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "dist/esm",
-    "target": "ESNext",
-    "module": "ESNext",
-  },
+  }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist/esm",
+    "target": "ESNext",
+    "module": "ESNext",
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "module": "ES2015",
     "moduleResolution": "Node",
     "outDir": "./dist",
-    "declaration": true,
+    "declaration": true
   },
   "ts-node": {
     "transpileOnly": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
     "module": "ES2015",
     "moduleResolution": "Node",
     "outDir": "./dist",
-    "declaration": true
+    "declaration": true,
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true,
+    "esm": true
   }
 }


### PR DESCRIPTION
Added outputs for both cjs and esm in build script. 

In the project I need to be able to import the shinami sdk as both a cjs and esm module. With these changes I should be able to.
