### PR TITLE
Migrate from deprecated usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shinami",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for Shinami services",
   "engines": {
     "node": ">=14"

--- a/src/gas.ts
+++ b/src/gas.ts
@@ -121,7 +121,7 @@ export async function buildGaslessTransactionBytes({
   if (build) await build(_txb);
   return toB64(
     await _txb.build({
-      provider: sui,
+      client: sui,
       onlyTransactionKind: true,
     })
   );

--- a/src/gas.ts
+++ b/src/gas.ts
@@ -3,7 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { JsonRpcProvider, TransactionBlock, toB64 } from "@mysten/sui.js";
+import { JsonRpcProvider } from "@mysten/sui.js";
+import { SuiClient } from "@mysten/sui.js/client";
+import { TransactionBlock } from "@mysten/sui.js/transactions";
+import { toB64 } from "@mysten/sui.js/utils";
 import { Infer, enums, number, object, optional, string } from "superstruct";
 import { ShinamiRpcClient } from "./rpc.js";
 
@@ -110,7 +113,7 @@ export async function buildGaslessTransactionBytes({
   txb,
   build,
 }: {
-  sui: JsonRpcProvider;
+  sui: SuiClient | JsonRpcProvider;
   txb?: TransactionBlock;
   build?: (txb: TransactionBlock) => Promise<void>;
 }): Promise<string> {

--- a/src/sui.ts
+++ b/src/sui.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Connection, JsonRpcProvider } from "@mysten/sui.js";
+import {
+  Connection,
+  DEFAULT_CLIENT_OPTIONS,
+  JsonRpcProvider,
+} from "@mysten/sui.js";
+import { SuiClient, SuiHTTPTransport } from "@mysten/sui.js/client";
 
 const NODE_RPC_URL = "https://api.shinami.com/node/v1";
 const NODE_WS_URL = "wss://api.shinami.com/node/v1";
@@ -27,4 +32,28 @@ export function createSuiProvider(
       websocket: `${wsUrl}/${accessKey}`,
     })
   );
+}
+
+/**
+ * Creates a Sui RPC client using Shinami Node service.
+ * @param accessKey Node access key. Note that the access key also determines which network you are
+ *    targeting.
+ * @param url Optional JSON RPC URL override.
+ * @param wsUrl Optional WebSocket URL override.
+ * @returns Sui RPC client using Shinami Node service.
+ */
+export function createSuiClient(
+  accessKey: string,
+  url: string = NODE_RPC_URL,
+  wsUrl: string = NODE_WS_URL
+): SuiClient {
+  return new SuiClient({
+    transport: new SuiHTTPTransport({
+      url: `${url}/${accessKey}`,
+      websocket: {
+        url: `${wsUrl}/${accessKey}`,
+        ...DEFAULT_CLIENT_OPTIONS,
+      },
+    }),
+  });
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -7,8 +7,8 @@ import {
   ExecuteTransactionRequestType,
   SuiTransactionBlockResponse,
   SuiTransactionBlockResponseOptions,
-  toB64,
-} from "@mysten/sui.js";
+} from "@mysten/sui.js/client";
+import { toB64 } from "@mysten/sui.js/utils";
 import { JSONRPCError } from "@open-rpc/client-js";
 import { Infer, object, string } from "superstruct";
 import { ShinamiRpcClient, errorDetails, trimTrailingParams } from "./rpc.js";

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -107,16 +107,18 @@ export class WalletClient extends ShinamiRpcClient {
    * @param walletId Wallet id.
    * @param sessionToken Session token, obtained by `KeyClient.createSession`.
    * @param message Base64 encoded personal message.
+   * @param wrapBcs If true, wrap the message bytes in a BCS struct before signing.
    * @returns Base64 encoded serialized signature.
    */
   signPersonalMessage(
     walletId: string,
     sessionToken: string,
-    message: string
+    message: string,
+    wrapBcs = true
   ): Promise<string> {
     return this.request(
       "shinami_wal_signPersonalMessage",
-      [walletId, sessionToken, message],
+      [walletId, sessionToken, message, wrapBcs],
       string()
     );
   }
@@ -281,12 +283,21 @@ export class ShinamiWalletSigner {
   /**
    * Signs a personal message with this wallet.
    * @param message Personal message bytes. If `string`, assumed to be Base64 encoded.
+   * @param wrapBcs If true, wrap the message bytes in a BCS struct before signing.
    * @returns Base64 encoded serialized signature.
    */
-  signPersonalMessage(message: string | Uint8Array): Promise<string> {
+  signPersonalMessage(
+    message: string | Uint8Array,
+    wrapBcs = true
+  ): Promise<string> {
     const _message = message instanceof Uint8Array ? toB64(message) : message;
     return this.withSession((session) =>
-      this.walletClient.signPersonalMessage(this.walletId, session, _message)
+      this.walletClient.signPersonalMessage(
+        this.walletId,
+        session,
+        _message,
+        wrapBcs
+      )
     );
   }
 

--- a/test/integration.env.ts
+++ b/test/integration.env.ts
@@ -7,7 +7,7 @@ import {
   GasStationClient,
   KeyClient,
   WalletClient,
-  createSuiProvider,
+  createSuiClient as createSuiClientImpl,
 } from "../src/index.js";
 
 // This is published to Testnet.
@@ -15,7 +15,7 @@ export const EXAMPLE_PACKAGE_ID =
   "0xd8f042479dcb0028d868051bd53f0d3a41c600db7b14241674db1c2e60124975";
 
 export function createSuiClient() {
-  return createSuiProvider(requireEnv("NODE_ACCESS_KEY"));
+  return createSuiClientImpl(requireEnv("NODE_ACCESS_KEY"));
 }
 
 export function createGasClient() {

--- a/test/wallet.integration.test.ts
+++ b/test/wallet.integration.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { describe, expect, it } from "@jest/globals";
-import { IntentScope, verifyMessage } from "@mysten/sui.js";
+import {
+  verifyPersonalMessage,
+  verifyTransactionBlock,
+} from "@mysten/sui.js/verify";
 import { v4 as uuidv4 } from "uuid";
 import {
   ShinamiWalletSigner,
@@ -61,17 +64,15 @@ describe("ShinamiWallet", () => {
   it("signs a transaction block", async () => {
     const txBytes = Uint8Array.from([1, 2, 3]);
     const { signature } = await signer.signTransactionBlock(txBytes);
-    expect(
-      await verifyMessage(txBytes, signature, IntentScope.TransactionData)
-    ).toBe(true);
+    const pubKey = await verifyTransactionBlock(txBytes, signature);
+    expect(pubKey.toSuiAddress()).toBe(await signer.getAddress());
   });
 
   it("signs a personal message", async () => {
     const message = Uint8Array.from([1, 2, 3]);
     const signature = await signer.signPersonalMessage(message);
-    expect(
-      await verifyMessage(message, signature, IntentScope.PersonalMessage)
-    ).toBe(true);
+    const pubKey = await verifyPersonalMessage(message, signature);
+    expect(pubKey.toSuiAddress()).toBe(await signer.getAddress());
   });
 
   it("executes gasless transaction block", async () => {
@@ -105,5 +106,5 @@ describe("ShinamiWallet", () => {
         },
       ],
     });
-  }, 10_000);
+  }, 30_000);
 });


### PR DESCRIPTION
Sui SDK is going through a refactor. Trying to keep up.

Note that this revealed a behavioral change in signing and verifying personal messages, which is currently failing CI. The bug is tracked by [sc-1336].

[UPDATE] - add support for `wrapBcs` on `signPersonalMessage` call, which defaults to `true` to match Sui SDK behavior. (The CI failure will be resolved once updated services are deployed).