### PR TITLE
Bug fix + Improvements

### DIFF
--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinami/clients",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "TypeScript clients for Shinami services",
   "sideEffects": false,
   "engines": {

--- a/packages/clients/src/aptos/wallet.ts
+++ b/packages/clients/src/aptos/wallet.ts
@@ -299,6 +299,7 @@ export class ShinamiWalletSigner {
   private readonly session: KeySession;
 
   private address?: AccountAddress;
+  private isInitialized: Boolean = false;
 
   constructor(
     walletId: string,
@@ -330,19 +331,24 @@ export class ShinamiWalletSigner {
 
   /**
    * Retrieves the wallet address if created in Shinami.
-   * You cannot use `getAddress` to initialize a wallet address on chain. Use `initializeWalletOnChain` instead.
    * @param autoCreate Whether to automatically create the wallet (off chain) if it doesn't exist yet in Shinami.
    *    If `false`, and the wallet doesn't exist, an error will be thrown.
-   * @param onChain whether to initialize the address on chain after creation. It will use the network
-   *    attached to the access key in the sessionToken. Only relevant if autoCreate is set to `true`
+   * @param onChain whether to initialize the address on chain. It will use the network attached to the access
+   *    key in the sessionToken.
    * @returns Wallet address.
    */
   async getAddress(
     autoCreate = false,
     onChain = false,
   ): Promise<AccountAddress> {
-    if (!this.address)
+    if (!this.address) {
+      // wallet has not yet been created or initialized
       this.address = await this._getAddress(autoCreate, onChain);
+    } else if (!this.isInitialized && onChain) {
+      // it is created in Shinami but not on chain, and onChain param is set
+      await this.tryInitializeOnChain();
+      this.isInitialized = true;
+    }
     return this.address;
   }
 
@@ -357,6 +363,26 @@ export class ShinamiWalletSigner {
         const address = await this.tryCreate(onChain);
         if (address) return address;
         return await this.walletClient.getWallet(this.walletId);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Tries to initialize this wallet on chain.
+   * @returns The wallet address that was successfully initialized on chain. `undefined` if this
+   *  wallet already exists on chain. An error will be thrown if wallet has not been created on
+   *  Shinami yet.
+   */
+  async tryInitializeOnChain(): Promise<AccountAddress | undefined> {
+    try {
+      return await this.session.withToken((token) =>
+        this.walletClient.initializeWalletOnChain(this.walletId, token),
+      );
+    } catch (e: unknown) {
+      if (e instanceof JSONRPCError && e.code === -32013) {
+        const details = errorDetails(e);
+        if (details?.details?.includes("already exists on-chain")) return;
       }
       throw e;
     }

--- a/packages/clients/src/aptos/wallet.ts
+++ b/packages/clients/src/aptos/wallet.ts
@@ -166,7 +166,7 @@ export class WalletClient extends ShinamiRpcClient {
         walletId,
         sessionToken,
         transaction.rawTransaction.bcsToHex().toString(),
-        transaction.secondarySignerAddresses?.map((x) => x.toString()),
+        transaction.secondarySignerAddresses?.map((x) => x.toString()) ?? [],
         transaction.feePayerAddress?.toString(),
       ]),
       SignTransactionResult,
@@ -329,8 +329,9 @@ export class ShinamiWalletSigner {
   }
 
   /**
-   * Retrieves the wallet address.
-   * @param autoCreate Whether to automatically create the wallet (off chain) if it doesn't exist yet.
+   * Retrieves the wallet address if created in Shinami.
+   * You cannot use `getAddress` to initialize a wallet address on chain. Use `initializeWalletOnChain` instead.
+   * @param autoCreate Whether to automatically create the wallet (off chain) if it doesn't exist yet in Shinami.
    *    If `false`, and the wallet doesn't exist, an error will be thrown.
    * @param onChain whether to initialize the address on chain after creation. It will use the network
    *    attached to the access key in the sessionToken. Only relevant if autoCreate is set to `true`

--- a/packages/clients/src/aptos/wallet.ts
+++ b/packages/clients/src/aptos/wallet.ts
@@ -299,7 +299,7 @@ export class ShinamiWalletSigner {
   private readonly session: KeySession;
 
   private address?: AccountAddress;
-  private isInitialized: Boolean = false;
+  private isInitialized: boolean = false;
 
   constructor(
     walletId: string,

--- a/packages/clients/src/aptos/wallet.ts
+++ b/packages/clients/src/aptos/wallet.ts
@@ -299,7 +299,7 @@ export class ShinamiWalletSigner {
   private readonly session: KeySession;
 
   private address?: AccountAddress;
-  private isInitialized: boolean = false;
+  private isInitialized = false;
 
   constructor(
     walletId: string,

--- a/packages/clients/src/aptos/wallet.ts
+++ b/packages/clients/src/aptos/wallet.ts
@@ -380,10 +380,7 @@ export class ShinamiWalletSigner {
         this.walletClient.initializeWalletOnChain(this.walletId, token),
       );
     } catch (e: unknown) {
-      if (e instanceof JSONRPCError && e.code === -32013) {
-        const details = errorDetails(e);
-        if (details?.details?.includes("already exists on-chain")) return;
-      }
+      if (e instanceof JSONRPCError && e.code === -32013) return;
       throw e;
     }
   }


### PR DESCRIPTION
- Fix signing signature in aptos wallet to correctly handle case with fee payer with no secondary signers
- Allow signer to initialize a Shinami created aptos wallet on chain via `getAddress`
- Explicitly have two wallet accounts for transfer transaction in aptos wallet tests
- Only verify sender is on chain if the sender is the fee payer in the transaction in aptos wallet tests.
- Add test case in aptos wallet for signing with fee payer