### PR TITLE
Remove explicit waits in test

### DIFF
--- a/packages/clients/test/sui/wallet.integration.test.ts
+++ b/packages/clients/test/sui/wallet.integration.test.ts
@@ -134,7 +134,6 @@ describe("ShinamiWallet", () => {
       beneficiary,
     );
     console.log("txDigest", txDigest);
-    await sui.waitForTransaction({ digest: txDigest });
 
     await expect(
       signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),
@@ -149,7 +148,6 @@ describe("ShinamiWallet", () => {
       beneficiary,
     );
     console.log("txDigest", txDigest);
-    await sui.waitForTransaction({ digest: txDigest });
 
     await expect(
       signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),
@@ -161,7 +159,6 @@ describe("ShinamiWallet", () => {
       EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
     );
     console.log("txDigest", txDigest);
-    await sui.waitForTransaction({ digest: txDigest });
 
     await expect(
       signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),


### PR DESCRIPTION
With the updated beneficiary APIs, we no longer need manual waits.

[sc-3767]