### PR TITLE
Fix Aptos wallet tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7098,7 +7098,7 @@
     },
     "packages/clients": {
       "name": "@shinami/clients",
-      "version": "0.9.5",
+      "version": "0.9.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/client-js": "^1.8.1",

--- a/packages/clients/README.md
+++ b/packages/clients/README.md
@@ -475,7 +475,9 @@ The integration tests for Aptos make use of the [Aptos Move example](../../examp
 Obtain `<your_aptos_super_access_key>` from [Shinami web portal](https://app.shinami.com/access-keys).
 The key must be authorized for all of these services, targeting _Aptos Testnet_:
 
+- Node service
 - Gas station - you must also have some available balance in your gas fund.
+- Wallet service
 
 Once you have the super keys for both chains,
 


### PR DESCRIPTION
`getAccountInfo` is no longer a reliable indicator of on-chain accounts. Explicitly get the account resource instead. CI should pass once https://github.com/shinamicorp/tf-infra/pull/1331 is deployed.

[sc-5789]