### PR TITLE
Update sdk for grpc migration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm ci
       - uses: actions/setup-python@v5 # needed by pre-commit
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npm ci
-      - uses: actions/setup-python@v5 # needed by pre-commit
+      - uses: actions/setup-python@v6 # needed by pre-commit
       - uses: pre-commit/action@v3.0.1
       - name: Client Tests
         env:
@@ -33,7 +33,7 @@ jobs:
         run: |
           npm run coverage
       - name: Upload reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./packages/clients/coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -41,8 +41,8 @@ jobs:
   check_copyright_header:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v7
         with:
           go-version: stable
       - run: go install github.com/google/addlicense@v1.1.1

--- a/.github/workflows/dep_compat.yaml
+++ b/.github/workflows/dep_compat.yaml
@@ -16,8 +16,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
       - run: npm update # Update to latest dep versions
@@ -26,7 +26,7 @@ jobs:
       # TypeScript 5.8. It already packages .d.ts files which are sufficient for type checking.
       - run: find node_modules/iron-session -name '*.ts' \! -name '*.d.ts' -print -delete
       - run: git add package-lock.json
-      - uses: actions/setup-python@v5 # needed by pre-commit
+      - uses: actions/setup-python@v6 # needed by pre-commit
       - uses: pre-commit/action@v3.0.1
       - run: npm run coverage
         env:

--- a/.github/workflows/dep_compat.yaml
+++ b/.github/workflows/dep_compat.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - run: npm update # Update to latest dep versions
       - run: npm ls --all # Print effective versions
       # Delete all .ts files from iron-session because they're packaged incompletely, which fails

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
           VERSION: ${{ steps.determine-package.outputs.VERSION }}
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "PACKAGE=$package" >> "$GITHUB_OUTPUT"
           echo "VERSION=$version" >> "$GITHUB_OUTPUT"
           echo "TAG=$tag" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: |
           source_version="$(jq -r .version < "packages/$PACKAGE/package.json")"
           if [ "$source_version" != "$VERSION" ]; then
@@ -73,7 +73,7 @@ jobs:
         env:
           PACKAGE: ${{ steps.determine-package.outputs.PACKAGE }}
           VERSION: ${{ steps.determine-package.outputs.VERSION }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           registry-url: "https://registry.npmjs.org"

--- a/examples/nextjs-zklogin/.env
+++ b/examples/nextjs-zklogin/.env
@@ -21,13 +21,18 @@
 #
 # SHINAMI_SUPER_ACCESS_KEY='Super key with access to Shinami gas station and wallet services. Only used on backend.'
 
-# Optional: override the Sui RPC endpoint for backend use.
+# Optional: override the Sui gRPC endpoint for backend use.
 # Defaults to the Mysten public fullnode for NEXT_PUBLIC_SUI_NETWORK.
 # SUI_RPC_URL='https://fullnode.testnet.sui.io:443'
 
-# Optional: override the Sui RPC endpoint for frontend use.
+# Optional: override the Sui gRPC endpoint for frontend use.
 # Defaults to the Mysten public fullnode for NEXT_PUBLIC_SUI_NETWORK.
 # NEXT_PUBLIC_SUI_RPC_URL='https://fullnode.testnet.sui.io:443'
+
+# Optional: override the Sui GraphQL endpoint for backend use.
+# Used only for queries with no gRPC equivalent
+# Defaults to the Mysten public GraphQL endpoint for NEXT_PUBLIC_SUI_NETWORK.
+# SUI_GRAPHQL_URL='https://graphql.testnet.sui.io/graphql'
 
 # 'devnet', 'testnet', or 'mainnet'
 NEXT_PUBLIC_SUI_NETWORK='testnet'

--- a/examples/nextjs-zklogin/lib/api/mysten.ts
+++ b/examples/nextjs-zklogin/lib/api/mysten.ts
@@ -1,4 +1,4 @@
-import { SuiClient } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { SaltProvider, ZkProofProvider } from "@shinami/nextjs-zklogin/server";
 import { SUI_NETWORK } from "../shared/sui";
 
@@ -10,9 +10,12 @@ const MYSTEN_PROVER_URL =
     : "https://prover-dev.mystenlabs.com/v1";
 
 /**
- * Mysten-operated Sui fullnode.
+ * Mysten-operated Sui fullnode, over gRPC.
  */
-export const mystenSui = new SuiClient({ url: MYSTEN_SUI_NODE_URL });
+export const mystenSui = new SuiGrpcClient({
+  baseUrl: MYSTEN_SUI_NODE_URL,
+  network: SUI_NETWORK,
+});
 
 /**
  * Mysten-operated salt server.

--- a/examples/nextjs-zklogin/lib/api/shinami.ts
+++ b/examples/nextjs-zklogin/lib/api/shinami.ts
@@ -1,4 +1,5 @@
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { SuiGraphQLClient } from "@mysten/sui/graphql";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import {
   GasStationClient,
   ZkProverClient,
@@ -13,13 +14,33 @@ const SHINAMI_SUPER_ACCESS_KEY =
   throwExpression(new Error("SHINAMI_SUPER_ACCESS_KEY not configured"));
 
 /**
- * A sui client for backend use only.
+ * A sui client for backend use only, over gRPC.
  *
  * Defaults to the Mysten public fullnode for the configured network.
  * Override by setting SUI_RPC_URL.
+ *
+ * For an authenticated endpoint, use GrpcWebFetchTransport with SuiGrpcClient
  */
-export const sui = new SuiClient({
-  url: process.env.SUI_RPC_URL ?? getFullnodeUrl(SUI_NETWORK),
+export const sui = new SuiGrpcClient({
+  baseUrl:
+    process.env.SUI_RPC_URL ?? `https://fullnode.${SUI_NETWORK}.sui.io:443`,
+  network: SUI_NETWORK,
+});
+
+/**
+ * A sui GraphQL client for backend use only.
+ *
+ * Used only for queries with no gRPC equivalent yet, e.g. listing recent transactions by sender.
+ * See: https://docs.sui.io/references/sui-api/graphql
+ *
+ * Defaults to the Mysten public GraphQL endpoint for the configured network.
+ * Override by setting SUI_GRAPHQL_URL.
+ */
+export const suiGraphql = new SuiGraphQLClient({
+  url:
+    process.env.SUI_GRAPHQL_URL ??
+    `https://graphql.${SUI_NETWORK}.sui.io/graphql`,
+  network: SUI_NETWORK,
 });
 
 /**

--- a/examples/nextjs-zklogin/lib/hooks/sui.ts
+++ b/examples/nextjs-zklogin/lib/hooks/sui.ts
@@ -1,4 +1,4 @@
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { SUI_NETWORK } from "../shared/sui";
 
 const SUI_VISION_BASE_URL = `https://${
@@ -18,11 +18,16 @@ export function getSuiVisionTransactionUrl(digest: string) {
 }
 
 /**
- * A sui client for frontend use.
+ * A sui client for frontend use, over gRPC.
  *
  * Defaults to the Mysten public fullnode for the configured network.
  * Override by setting NEXT_PUBLIC_SUI_RPC_URL.
+ *
+ * For an authenticated endpoint, use GrpcWebFetchTransport with SuiGrpcClient
  */
-export const sui = new SuiClient({
-  url: process.env.NEXT_PUBLIC_SUI_RPC_URL ?? getFullnodeUrl(SUI_NETWORK),
+export const sui = new SuiGrpcClient({
+  baseUrl:
+    process.env.NEXT_PUBLIC_SUI_RPC_URL ??
+    `https://fullnode.${SUI_NETWORK}.sui.io:443`,
+  network: SUI_NETWORK,
 });

--- a/examples/nextjs-zklogin/lib/shared/sui.ts
+++ b/examples/nextjs-zklogin/lib/shared/sui.ts
@@ -1,9 +1,8 @@
-import { getFullnodeUrl } from "@mysten/sui/client";
+import { SuiClientTypes } from "@mysten/sui/client";
 import { throwExpression } from "./utils";
 
-export type SuiNetwork = Parameters<typeof getFullnodeUrl>[0];
-
-export const SUI_NETWORK: SuiNetwork = (process.env.NEXT_PUBLIC_SUI_NETWORK ??
+export const SUI_NETWORK: SuiClientTypes.Network = (process.env
+  .NEXT_PUBLIC_SUI_NETWORK ??
   throwExpression(
     new Error("NEXT_PUBLIC_SUI_NETWORK not configured"),
-  )) as SuiNetwork;
+  )) as SuiClientTypes.Network;

--- a/examples/nextjs-zklogin/package.json
+++ b/examples/nextjs-zklogin/package.json
@@ -6,7 +6,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@mysten/sui": ">=2.0.0",
+    "@mysten/sui": "^2.0.0",
     "@shinami/clients": "^0.12.0",
     "@shinami/nextjs-zklogin": "^0.5.0",
     "next": "latest",

--- a/examples/nextjs-zklogin/package.json
+++ b/examples/nextjs-zklogin/package.json
@@ -6,6 +6,8 @@
     "start": "next start"
   },
   "dependencies": {
+    "@mysten/sui": ">=2.0.0",
+    "@shinami/clients": "^0.11.0",
     "@shinami/nextjs-zklogin": "^0.4.1",
     "next": "latest",
     "react": "^18.2.0",

--- a/examples/nextjs-zklogin/package.json
+++ b/examples/nextjs-zklogin/package.json
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "@mysten/sui": ">=2.0.0",
-    "@shinami/clients": "^0.11.0",
-    "@shinami/nextjs-zklogin": "^0.4.1",
+    "@shinami/clients": "^0.12.0",
+    "@shinami/nextjs-zklogin": "^0.5.0",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/examples/nextjs-zklogin/pages/api/add/[...api].ts
+++ b/examples/nextjs-zklogin/pages/api/add/[...api].ts
@@ -37,12 +37,16 @@ const buildTx: GaslessTransactionBuilder = async (req, { wallet }) => {
 /**
  * Parses the transaction response.
  */
-const parseTxRes: TransactionResponseParser<AddResponse> = (_, txRes) => {
-  // Requires "showEvents: true" in tx response options.
+const parseTxRes: TransactionResponseParser<
+  unknown,
+  AddResponse,
+  { events: true }
+> = (_, txRes) => {
+  // Requires "events: true" in tx response include options.
   const event = first(txRes.events);
   if (!event) throw new Error("Event missing from tx response");
 
-  const result = mask(event.parsedJson, AddResult);
+  const result = mask(event.json, AddResult);
   return { ...result, txDigest: txRes.digest };
 };
 
@@ -57,5 +61,5 @@ const parseTxRes: TransactionResponseParser<AddResponse> = (_, txRes) => {
  * user to have a live session.
  */
 export default zkLoginSponsoredTxExecHandler(sui, gas, buildTx, parseTxRes, {
-  showEvents: true,
+  events: true,
 });

--- a/examples/nextjs-zklogin/pages/api/recent_txs.ts
+++ b/examples/nextjs-zklogin/pages/api/recent_txs.ts
@@ -38,8 +38,12 @@ export default withZkLoginUserRequired<RecentTxsResponse>(
       );
     }
 
+    if (!data) {
+      throw new Error("GraphQL query returned no data");
+    }
+
     res.json({
-      txDigests: data!.transactions.nodes.map((x) => x.digest).reverse(),
+      txDigests: data.transactions.nodes.map((x) => x.digest).reverse(),
     });
   },
 );

--- a/examples/nextjs-zklogin/pages/api/recent_txs.ts
+++ b/examples/nextjs-zklogin/pages/api/recent_txs.ts
@@ -1,18 +1,45 @@
-import { sui } from "@/lib/api/shinami";
+import { sui, suiGraphql } from "@/lib/api/shinami";
 import { RecentTxsResponse } from "@/lib/shared/interfaces";
 import { withZkLoginUserRequired } from "@shinami/nextjs-zklogin/server/pages";
+
+interface RecentTransactionsQueryResult {
+  transactions: {
+    nodes: { digest: string }[];
+  };
+}
 
 // This is an auth-protected API route, augmented with user's zkLogin info.
 export default withZkLoginUserRequired<RecentTxsResponse>(
   sui,
   async (_, res, user) => {
     // This Sui query can easily be performed on the client side as well.
-    const txs = await sui.queryTransactionBlocks({
-      filter: { FromAddress: user.wallet },
-      order: "descending",
-      limit: 5,
-    });
+    //
+    // Uses GraphQL because "queryTransactionBlocks" (JSON-RPC) has no gRPC equivalent.
+    // "last" (not "first") is required to get the most recent transactions - the connection is
+    // ordered oldest to newest, so "first" would return the oldest ones instead.
+    const { data, errors } =
+      await suiGraphql.query<RecentTransactionsQueryResult>({
+        query: `
+          query RecentTransactions($sender: SuiAddress!, $last: Int) {
+            transactions(last: $last, filter: { sentAddress: $sender }) {
+              nodes {
+                digest
+              }
+            }
+          }
+        `,
+        variables: { sender: user.wallet, last: 5 },
+      });
 
-    res.json({ txDigests: txs.data.map((x) => x.digest) });
+    if (errors?.length) {
+      console.error("GraphQL errors", errors);
+      throw new Error(
+        `Failed to query recent transactions: ${errors[0].message}`,
+      );
+    }
+
+    res.json({
+      txDigests: data!.transactions.nodes.map((x) => x.digest).reverse(),
+    });
   },
 );

--- a/examples/nextjs-zklogin/tsconfig.json
+++ b/examples/nextjs-zklogin/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
     },
     "examples/nextjs-zklogin": {
       "dependencies": {
+        "@mysten/sui": ">=2.0.0",
+        "@shinami/clients": "^0.11.0",
         "@shinami/nextjs-zklogin": "^0.4.1",
         "next": "latest",
         "react": "^18.2.0",
@@ -30,9 +32,10 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.7.tgz",
-      "integrity": "sha512-E3Qku4mTzdrlwVWGPxklDnME5ANrEGetvYw4i2GCRlppWXXE4QD66j7pwb8HelZwS6LnqEChhrSOGCXpbiu6MQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.3.2.tgz",
+      "integrity": "sha512-Q1+pRlLhE31GOY/2c9BAEnFTNxO7Awtc6fhhEDlxyCBQ2N0IhD32cPVvPChrK9mwBNSgRdW/sF1kd2e0ojHj1Q==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -43,22 +46,24 @@
       }
     },
     "node_modules/@0no-co/graphqlsp": {
-      "version": "1.12.5",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.5.tgz",
-      "integrity": "sha512-YS9s8sf3XLaVdBt33u1mbUdfUSLiarQW1SFd3ITh2CLWz1nVnVTN0oCrpepuFHUJ7rt+b6Gk14sgjP4ONdeZfQ==",
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.17.3.tgz",
+      "integrity": "sha512-4PPvxDPmbntddpgMyA3VId5/E9YGdRuuS/mW+THOvtTx/C79Pf+lN28LkNNACJrF9L7YACiAJelyOkC6LqUzvw==",
+      "license": "MIT",
       "dependencies": {
-        "@gql.tada/internal": "^1.0.0",
+        "@gql.tada/internal": "^1.2.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -420,6 +425,7 @@
       "version": "7.24.4",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.4.tgz",
       "integrity": "sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -757,32 +763,42 @@
       }
     },
     "node_modules/@gql.tada/cli-utils": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.3.9.tgz",
-      "integrity": "sha512-oRb7SG/+csx9CiypSJTI21KaLfulOUnhX1vxg4FXi2snub9XShkGR2XnnlJVTAOZXY9Vcxti1NutAElxdDkycA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.9.2.tgz",
+      "integrity": "sha512-cVNs4v8ewLRYJfyAsaHbiAmd5Hm+zXEMvMhBksH58ZU87d6f8crsp2CQG6QtIqnJJw1q0CBWfWTZepGWNcL3QA==",
+      "license": "MIT",
       "dependencies": {
-        "@0no-co/graphqlsp": "^1.12.1",
-        "@gql.tada/internal": "1.0.0",
-        "@vue/compiler-dom": "^3.4.23",
-        "@vue/language-core": "^2.0.17",
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "svelte2tsx": "^0.7.6"
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/internal": "1.2.1",
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
       },
       "peerDependencies": {
+        "@0no-co/graphqlsp": "^1.16.0",
+        "@gql.tada/svelte-support": "1.0.3",
+        "@gql.tada/vue-support": "1.0.3",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@gql.tada/svelte-support": {
+          "optional": true
+        },
+        "@gql.tada/vue-support": {
+          "optional": true
+        }
       }
     },
     "node_modules/@gql.tada/internal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.0.tgz",
-      "integrity": "sha512-B55aIYyZn5ewdgMqoJciPAwF5DKYX6HBabTU+ap/dpNH3EgJrLomc8Y8w+MCxCyOx+dXL9OduT6eWnVr7J7Eyg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.2.1.tgz",
+      "integrity": "sha512-1kPMv9KRpD6mfVwtXK+iy43U/gi4bpr4ganfhPLD0TjxpbuVJm7CtZ9wMFdwy3FjLBFN2QhwscNnL7lRPHg4vg==",
+      "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5"
+        "@0no-co/graphql.web": "^1.3.1"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
@@ -1682,6 +1698,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1695,6 +1712,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1703,6 +1721,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1710,12 +1729,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1731,25 +1752,29 @@
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.0.4.tgz",
-      "integrity": "sha512-75yxOlnsHo0lapJaUR7KRQvymMPz9roDZ64onaRi109JToOqPxfegvFm7016kf1AgmnXT1TQiYue4ntGts5tsA==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.20.1.tgz",
+      "integrity": "sha512-gf7p3biAr+456dIFHFZUEvUn52vFhkjdJ6zM8FQoC9Ox75ApfkM8vT6iUiSNBjkNlGWJ54g3+6hHYv75F+ST4A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.0.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "@scure/bip32": "^1.3.1",
-        "@scure/bip39": "^1.2.1",
-        "@suchipi/femver": "^1.0.0",
-        "bech32": "^2.0.0",
-        "gql.tada": "^1.7.0",
-        "graphql": "^16.8.1",
-        "tweetnacl": "^1.0.3",
-        "valibot": "^0.25.0"
+        "@mysten/bcs": "^2.1.0",
+        "@mysten/utils": "^0.4.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@protobuf-ts/grpcweb-transport": "^2.11.1",
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1",
+        "@scure/base": "^2.2.0",
+        "@scure/bip32": "^2.2.0",
+        "@scure/bip39": "^2.2.0",
+        "gql.tada": "^1.10.1",
+        "graphql": "^16.14.2",
+        "poseidon-lite": "0.2.1",
+        "valibot": "^1.4.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@mysten/sui.js": {
@@ -1776,31 +1801,85 @@
       }
     },
     "node_modules/@mysten/sui/node_modules/@mysten/bcs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.0.1.tgz",
-      "integrity": "sha512-ZcK3hkCxRcbMxuLgFf/dLTAVTkOg8J5e3QdQcbefh07Ja78O7M8nLgsgeBiNzWAuaD0B47DX0PoxxON8UngTaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.1.0.tgz",
+      "integrity": "sha512-rIR/cDAqDfBDxmYEZXppN/on8gmh1OW0dYi/Bk2kMBZcYMTaBaEtEX1VR6g7HicVxuMbFAIP0/SQkdH7J9Y5dQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bs58": "^5.0.0"
+        "@mysten/utils": "^0.4.0",
+        "@scure/base": "^2.2.0"
       }
     },
-    "node_modules/@mysten/zklogin": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@mysten/zklogin/-/zklogin-0.7.4.tgz",
-      "integrity": "sha512-NjAHxE/2nkflWNyh67GIIDsmyRQX/8yBOmkeJLDCu3KE2Axylv+X7t61D6LIDF/oyoHOVxeODziTPCTA/spytg==",
+    "node_modules/@mysten/sui/node_modules/@mysten/utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.4.0.tgz",
+      "integrity": "sha512-nHlXECBl9kE+AHF/aw5a7JVNizae8Kb71A4H18BV/sXd5/l2BaWNGWVatq05fzJo3hF78AWorDxa++1TgcBKWw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/bcs": "1.0.1",
-        "@mysten/sui": "1.0.4",
-        "@noble/hashes": "^1.3.1",
-        "jose": "^5.2.3",
-        "poseidon-lite": "^0.2.0"
+        "@scure/base": "^2.2.0"
       }
     },
-    "node_modules/@mysten/zklogin/node_modules/@mysten/bcs": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.0.1.tgz",
-      "integrity": "sha512-ZcK3hkCxRcbMxuLgFf/dLTAVTkOg8J5e3QdQcbefh07Ja78O7M8nLgsgeBiNzWAuaD0B47DX0PoxxON8UngTaQ==",
+    "node_modules/@mysten/sui/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
       "dependencies": {
-        "bs58": "^5.0.0"
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@mysten/sui/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@mysten/sui/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@mysten/sui/node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@mysten/sui/node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@next/env": {
@@ -1938,22 +2017,27 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
-      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.4.0"
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2041,34 +2125,62 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/@protobuf-ts/grpcweb-transport": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz",
+      "integrity": "sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1"
+      }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1"
+      }
+    },
     "node_modules/@scure/base": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
-      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -2121,7 +2233,8 @@
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
-      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
+      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg==",
+      "peer": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -2296,12 +2409,6 @@
         "@types/keygrip": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "peer": true
     },
     "node_modules/@types/express": {
       "version": "4.17.21",
@@ -2845,96 +2952,11 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/@volar/language-core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.2.5.tgz",
-      "integrity": "sha512-2htyAuxRrAgETmFeUhT4XLELk3LiEcqoW/B8YUXMF6BrGWLMwIR09MFaZYvrA2UhbdAeSyeQ726HaWSWkexUcQ==",
-      "dependencies": {
-        "@volar/source-map": "2.2.5"
-      }
-    },
-    "node_modules/@volar/source-map": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.2.5.tgz",
-      "integrity": "sha512-wrOEIiZNf4E+PWB0AxyM4tfhkfldPsb3bxg8N6FHrxJH2ohar7aGu48e98bp3pR9HUA7P/pR9VrLmkTrgCCnWQ==",
-      "dependencies": {
-        "muggle-string": "^0.4.0"
-      }
-    },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
-      "dependencies": {
-        "@babel/parser": "^7.24.4",
-        "@vue/shared": "3.4.27",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-      "dependencies": {
-        "@vue/compiler-core": "3.4.27",
-        "@vue/shared": "3.4.27"
-      }
-    },
-    "node_modules/@vue/language-core": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.0.19.tgz",
-      "integrity": "sha512-A9EGOnvb51jOvnCYoRLnMP+CcoPlbZVxI9gZXE/y2GksRWM6j/PrLEIC++pnosWTN08tFpJgxhSS//E9v/Sg+Q==",
-      "dependencies": {
-        "@volar/language-core": "~2.2.4",
-        "@vue/compiler-dom": "^3.4.0",
-        "@vue/shared": "^3.4.0",
-        "computeds": "^0.0.1",
-        "minimatch": "^9.0.3",
-        "path-browserify": "^1.0.1",
-        "vue-template-compiler": "^2.7.14"
-      },
-      "peerDependencies": {
-        "typescript": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@vue/language-core/node_modules/minimatch": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
-      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.4.27",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
-    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3052,15 +3074,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -3105,15 +3118,6 @@
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/axobject-query": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
-      "integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
       }
     },
     "node_modules/babel-jest": {
@@ -3226,12 +3230,14 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==",
+      "peer": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -3255,7 +3261,8 @@
     "node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3328,6 +3335,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
       "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "peer": true,
       "dependencies": {
         "base-x": "^4.0.0"
       }
@@ -3522,28 +3530,6 @@
         "node": ">= 0.12.0"
       }
     },
-    "node_modules/code-red": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-      "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.10.0",
-        "estree-walker": "^3.0.3",
-        "periscopic": "^3.1.0"
-      }
-    },
-    "node_modules/code-red/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
@@ -3579,11 +3565,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/computeds": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
-      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3646,29 +3627,11 @@
         "node": ">= 8"
       }
     },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "peer": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
-    },
-    "node_modules/de-indent": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3728,11 +3691,6 @@
         }
       }
     },
-    "node_modules/dedent-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ=="
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3764,15 +3722,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3883,17 +3832,6 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4071,11 +4009,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -4508,20 +4441,22 @@
       }
     },
     "node_modules/gql.tada": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.7.5.tgz",
-      "integrity": "sha512-GepPTee+FWSVVZQ7GiJHzsGNo7gOb59kcn4mUPYLlkbpeJfOUwpuoB05ZNaXG0W4qZVPd1I7R2UgMHBjY1lGlQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.11.2.tgz",
+      "integrity": "sha512-oBr7ShA5/TmcwOO7BZgN1SynX2rBU+/ltysB0zXc+NCBF+9YOg6MRzJcTfLjIqDKdcE3LGxpOl0l9hBbxmyzmA==",
+      "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5",
-        "@gql.tada/cli-utils": "1.3.9",
-        "@gql.tada/internal": "1.0.0"
+        "@0no-co/graphql.web": "^1.3.2",
+        "@0no-co/graphqlsp": "^1.17.3",
+        "@gql.tada/cli-utils": "1.9.2",
+        "@gql.tada/internal": "1.2.1"
       },
       "bin": {
         "gql-tada": "bin/cli.js",
         "gql.tada": "bin/cli.js"
       },
       "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/graceful-fs": {
@@ -4537,9 +4472,10 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -4563,14 +4499,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": {
-        "he": "bin/he"
       }
     },
     "node_modules/html-escaper": {
@@ -4818,15 +4746,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-reference": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
-      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*"
       }
     },
     "node_modules/is-stream": {
@@ -5571,9 +5490,10 @@
       }
     },
     "node_modules/jose": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
-      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -5689,12 +5609,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "node_modules/locate-character": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-      "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "peer": true
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5733,14 +5647,6 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -5757,15 +5663,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/make-dir": {
@@ -5830,12 +5727,6 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5922,11 +5813,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
-    "node_modules/muggle-string": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
-      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -6005,15 +5891,6 @@
     "node_modules/nextjs-zklogin": {
       "resolved": "examples/nextjs-zklogin",
       "link": true
-    },
-    "node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -6198,20 +6075,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6252,26 +6115,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/periscopic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-      "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0",
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0"
-      }
-    },
-    "node_modules/periscopic/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/picocolors": {
@@ -6365,9 +6208,10 @@
       }
     },
     "node_modules/poseidon-lite": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.0.tgz",
-      "integrity": "sha512-vivDZnGmz8W4G/GzVA72PXkfYStjilu83rjjUfpL4PueKcC8nfX6hCPh2XhoC5FBgC6y0TA3YuUeUo5YCcNoig=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.2.1.tgz",
+      "integrity": "sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.31",
@@ -7013,53 +6857,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svelte": {
-      "version": "4.2.17",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.17.tgz",
-      "integrity": "sha512-N7m1YnoXtRf5wya5Gyx3TWuTddI4nAyayyIWFojiWV5IayDYNV5i2mRp/7qNGol4DtxEYxljmrbgp1HM6hUbmQ==",
-      "peer": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "@types/estree": "^1.0.1",
-        "acorn": "^8.9.0",
-        "aria-query": "^5.3.0",
-        "axobject-query": "^4.0.0",
-        "code-red": "^1.0.3",
-        "css-tree": "^2.3.1",
-        "estree-walker": "^3.0.3",
-        "is-reference": "^3.0.1",
-        "locate-character": "^3.0.0",
-        "magic-string": "^0.30.4",
-        "periscopic": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/svelte/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/svelte2tsx": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/svelte2tsx/-/svelte2tsx-0.7.9.tgz",
-      "integrity": "sha512-Rm+0LAwg9wT4H2IsR8EaM9EWErTzi9LmuZKxkH5b1ua94XjQmwHstBP4VabLgA9AE6XmwBg+xK7Cjzwfm6ustQ==",
-      "dependencies": {
-        "dedent-js": "^1.0.1",
-        "pascal-case": "^3.1.1"
-      },
-      "peerDependencies": {
-        "svelte": "^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0",
-        "typescript": "^4.9.4 || ^5.0.0"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7259,7 +7056,8 @@
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7295,9 +7093,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7410,17 +7209,17 @@
       }
     },
     "node_modules/valibot": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.25.0.tgz",
-      "integrity": "sha512-cmD0ca15oyAbT75iYLNW6uU6doAeIwYfOshpXka/E1Bx4frzbkrgb7gvkI7K0YK/DVOksei4FfxWfRoBP3NFTg=="
-    },
-    "node_modules/vue-template-compiler": {
-      "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-      "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
-      "dependencies": {
-        "de-indent": "^1.0.2",
-        "he": "^1.2.0"
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/walker": {
@@ -7617,7 +7416,8 @@
       },
       "devDependencies": {
         "@aptos-labs/ts-sdk": ">=1.13.3",
-        "@mysten/sui": ">=1.0.4",
+        "@mysten/sui": "^2.0.0",
+        "@protobuf-ts/runtime": "^2.11.1",
         "@tsconfig/recommended": "^1.0.3",
         "@types/uuid": "^9.0.2",
         "eslint": "^8.57.0",
@@ -7633,7 +7433,7 @@
       },
       "peerDependencies": {
         "@aptos-labs/ts-sdk": ">=1.13.3",
-        "@mysten/sui": ">=1.0.4"
+        "@mysten/sui": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "@aptos-labs/ts-sdk": {
@@ -7716,13 +7516,14 @@
       "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/zklogin": "^0.7.4",
         "@shinami/clients": "^0.11.0",
         "@tanstack/react-query": "^5.0.5",
         "iron-session": "^6.3.1",
+        "jose": "^6.2.3",
         "superstruct": "^2.0.2"
       },
       "devDependencies": {
+        "@mysten/sui": ">=2.0.0",
         "@tsconfig/recommended": "^1.0.3",
         "@types/react": "^18.2.31",
         "eslint": "^8.57.0",
@@ -7733,6 +7534,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "@mysten/sui": ">=2.0.0",
         "next": ">=13"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7517,8 +7517,8 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=7.2.0",
-        "@mysten/sui": ">=2.0.0"
+        "@aptos-labs/ts-sdk": "^7.2.0",
+        "@mysten/sui": "^2.0.0"
       },
       "peerDependenciesMeta": {
         "@aptos-labs/ts-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
     "examples/nextjs-zklogin": {
       "dependencies": {
         "@mysten/sui": ">=2.0.0",
-        "@shinami/clients": "^0.11.0",
-        "@shinami/nextjs-zklogin": "^0.4.1",
+        "@shinami/clients": "^0.12.0",
+        "@shinami/nextjs-zklogin": "^0.5.0",
         "next": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -7408,7 +7408,7 @@
     },
     "packages/clients": {
       "name": "@shinami/clients",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@open-rpc/client-js": "^2.0.0",
@@ -7429,7 +7429,7 @@
         "uuid": "^9.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@aptos-labs/ts-sdk": ">=1.13.3",
@@ -7513,10 +7513,10 @@
     },
     "packages/nextjs-zklogin": {
       "name": "@shinami/nextjs-zklogin",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@shinami/clients": "^0.11.0",
+        "@shinami/clients": "^0.12.0",
         "@tanstack/react-query": "^5.0.5",
         "iron-session": "^6.3.1",
         "jose": "^6.2.3",
@@ -7531,7 +7531,7 @@
         "typescript-eslint": "^7.7.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@mysten/sui": ">=2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     },
     "examples/nextjs-zklogin": {
       "dependencies": {
-        "@mysten/sui": ">=2.0.0",
+        "@mysten/sui": "^2.0.0",
         "@shinami/clients": "^0.12.0",
         "@shinami/nextjs-zklogin": "^0.5.0",
         "next": "latest",
@@ -7500,7 +7500,7 @@
         "superstruct": "^2.0.2"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": ">=7.2.0",
+        "@aptos-labs/ts-sdk": "^7.2.0",
         "@mysten/sui": "^2.0.0",
         "@protobuf-ts/runtime": "^2.11.1",
         "@tsconfig/recommended": "^1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,45 +73,139 @@
       }
     },
     "node_modules/@aptos-labs/aptos-cli": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-cli/-/aptos-cli-0.1.8.tgz",
-      "integrity": "sha512-xSWDchqoDR4aR74xNoJZgOzIFtn+EKFGGFLG0vOb+6Ce8Jgg1Ui0Pqhvwbx6Z36dDxfKv0F4M7bnurvWpwAjXA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-cli/-/aptos-cli-3.0.0.tgz",
+      "integrity": "sha512-fw9Ph6pe9l/RW6LMqjpxrHiWo2T/gtYWZsRxgl4PqVroavGF13YEQWlUnjJfWgVi1wQHpQcoJ1eYbYsPFu2sVg==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
       "dev": true,
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "commander": "^14.0.3"
+      },
       "bin": {
-        "aptos": "bin/aptos"
+        "aptos": "dist/aptos.js"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@aptos-labs/aptos-client": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.0.tgz",
-      "integrity": "sha512-q3s6pPq8H2buGp+tPuIRInWsYOuhSEwuNJPwd2YnsiID3YSLihn2ug39ktDJAcSOprUcp7Nid8WK7hKqnUmSdA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-4.1.0.tgz",
+      "integrity": "sha512-QNr8OV3b6oZB+5LSh86wee9RbK+FAYCKh0wvu3epSf5JJnHezszpnAgtr3DJGBG6t00MJHaiu6VUbmujrl97iQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "axios": "1.6.2",
-        "got": "^11.8.6"
+        "got": "^15.0.5"
       },
       "engines": {
-        "node": ">=15.10.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@aptos-labs/ts-sdk": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-1.13.3.tgz",
-      "integrity": "sha512-DVEPx11ySORsJ8q1CqcDZ7OIYuhGeHPqRBUCR9xfan/WxENqQKo8NyD+AfZJPlbcqmt76Ff8Zlp0twDk3nPbYw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/ts-sdk/-/ts-sdk-7.2.0.tgz",
+      "integrity": "sha512-XlMyyUCuMnpjvVsxN3CiShWAeHw2spTV+j4xqE1os3FXr2b9ufxiEnXGJVug3eZfAEGWhreIFuqj6i+fzC1dQA==",
       "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@aptos-labs/aptos-cli": "^0.1.2",
-        "@aptos-labs/aptos-client": "^0.1.0",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "@scure/bip32": "^1.4.0",
-        "@scure/bip39": "^1.3.0",
-        "eventemitter3": "^5.0.1",
-        "form-data": "^4.0.0"
+        "@aptos-labs/aptos-cli": "^3.0.0",
+        "@aptos-labs/aptos-client": "^4.1.0",
+        "@noble/ciphers": "2.2.0",
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1",
+        "eventemitter3": "^5.0.4",
+        "jwt-decode": "^4.0.0",
+        "poseidon-lite": "^0.3.0"
       },
       "engines": {
-        "node": ">=11.0.0"
+        "node": ">=22.0.0"
       }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/@scure/bip39": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@aptos-labs/ts-sdk/node_modules/poseidon-lite": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/poseidon-lite/-/poseidon-lite-0.3.0.tgz",
+      "integrity": "sha512-ilJj4MIve4uBEG7SrtPqUUNkvpJ/pLVbndxa0WvebcQqeIhe+h72JR4g0EvwchUzm9sOQDlOjiDNmRAgxNZl4A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.2",
@@ -1742,6 +1836,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+      "integrity": "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@mysten/bcs": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
@@ -2016,11 +2117,25 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -2036,6 +2151,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2155,6 +2271,7 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -2164,6 +2281,7 @@
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
       "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.9.0",
         "@noble/hashes": "~1.8.0",
@@ -2178,6 +2296,7 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
       "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
@@ -2185,6 +2304,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@shinami/clients": {
       "resolved": "packages/clients",
@@ -2201,12 +2327,13 @@
       "dev": true
     },
     "node_modules/@sindresorhus/is": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
+      "integrity": "sha512-2SX/1jW6CIMAiebvVv5ZInoCEuWQmMyBoJXXGC6Vjakjp/fpxP5eHs7/V6WKuPEIbuK06+VpjH+vjLQhr98rDQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
@@ -2243,18 +2370,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-      "dev": true,
-      "dependencies": {
-        "defer-to-connect": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -2369,18 +2484,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cacheable-request": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-cache-semantics": "*",
-        "@types/keyv": "^3.1.4",
-        "@types/node": "*",
-        "@types/responselike": "^1.0.0"
-      }
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2447,10 +2550,11 @@
       "integrity": "sha512-4+tE/lwdAahgZT1g30Jkdm9PzFRde0xwxBNUyRsCitRvCQB90iuA2uJYdUnhnANRcqGXaWOGY4FEoxeElNAK2g=="
     },
     "node_modules/@types/http-cache-semantics": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
@@ -2491,15 +2595,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
       "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ=="
-    },
-    "node_modules/@types/keyv": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/koa": {
       "version": "2.15.0",
@@ -2570,15 +2665,6 @@
       "dev": true,
       "dependencies": {
         "@types/react": "*"
-      }
-    },
-    "node_modules/@types/responselike": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -3103,23 +3189,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
-    },
-    "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -3378,31 +3447,56 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
-    "node_modules/cacheable-lookup": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+    "node_modules/byte-counter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/byte-counter/-/byte-counter-0.1.0.tgz",
+      "integrity": "sha512-jheRLVMeUKrDBjVw2O5+k4EvR4t9wtxHL+bo/LxfkxsVeuGMy3a5SEGgXdAFA4FSzTrU8rQXQIrsZ3oBq5a0pQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10.6.0"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       }
     },
     "node_modules/cacheable-request": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "version": "13.0.19",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-13.0.19.tgz",
+      "integrity": "sha512-SVXGH037+Mo1aIMO5B2UcleR43FGjFdN+M8JObSyEoQ2Mn4CODRWx28gN5jiTF0n5ItsgtIZfyargMNs8GX4kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "clone-response": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "http-cache-semantics": "^4.0.0",
-        "keyv": "^4.0.0",
-        "lowercase-keys": "^2.0.0",
-        "normalize-url": "^6.0.1",
-        "responselike": "^2.0.0"
+        "@types/http-cache-semantics": "^4.2.0",
+        "get-stream": "^9.0.1",
+        "http-cache-semantics": "^4.2.0",
+        "keyv": "^5.6.0",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.1.1",
+        "responselike": "^4.0.2"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
       }
     },
     "node_modules/callsites": {
@@ -3467,6 +3561,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/chunk-data": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chunk-data/-/chunk-data-0.1.0.tgz",
+      "integrity": "sha512-zFyPtyC0SZ6Zu79b9sOYtXZcgrsXe0RpePrzRyj52hYVFG1+Rk6rBqjjOEk+GNQwc3PIX+86teQMok970pod1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -3508,18 +3615,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone-response": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "dev": true,
-      "dependencies": {
-        "mimic-response": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -3554,16 +3649,14 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=20"
       }
     },
     "node_modules/concat-map": {
@@ -3651,27 +3744,16 @@
       }
     },
     "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-10.0.0.tgz",
+      "integrity": "sha512-oj7KWToJuuxlPr7VV0vabvxEIiqNMo+q0NueIiL3XhtwC6FVOX7Hr1c0C4eD0bmf7Zr+S/dSf2xvkH3Ad6sU3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "mimic-response": "^3.1.0"
+        "mimic-response": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3704,24 +3786,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/defer-to-connect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -3824,15 +3888,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -4020,10 +4075,11 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -4243,40 +4299,6 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4334,15 +4356,30 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "pump": "^3.0.0"
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-stream/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4416,28 +4453,56 @@
       }
     },
     "node_modules/got": {
-      "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-15.1.0.tgz",
+      "integrity": "sha512-DG+DAAkRtno+oDr/GBsliAkhN9+zczOPM5qXk3efDZY3qvyRnZU+NwQlb/IOY6cSnxxTR9z3aHCcShJyjb0hJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@sindresorhus/is": "^4.0.0",
-        "@szmarczak/http-timer": "^4.0.5",
-        "@types/cacheable-request": "^6.0.1",
-        "@types/responselike": "^1.0.0",
-        "cacheable-lookup": "^5.0.3",
-        "cacheable-request": "^7.0.2",
-        "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.5.2",
-        "lowercase-keys": "^2.0.0",
-        "p-cancelable": "^2.0.0",
-        "responselike": "^2.0.0"
+        "@sindresorhus/is": "^8.0.0",
+        "byte-counter": "^0.1.0",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^13.0.18",
+        "chunk-data": "^0.1.0",
+        "decompress-response": "^10.0.0",
+        "http2-wrapper": "^2.2.1",
+        "keyv": "^5.6.0",
+        "lowercase-keys": "^4.0.1",
+        "responselike": "^4.0.2",
+        "type-fest": "^5.6.0",
+        "uint8array-extras": "^1.5.0"
       },
       "engines": {
-        "node": ">=10.19.0"
+        "node": ">=22"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/keyv": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+      "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.1"
+      }
+    },
+    "node_modules/got/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gql.tada": {
@@ -4508,19 +4573,21 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/http2-wrapper": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
-        "resolve-alpn": "^1.0.0"
+        "resolve-alpn": "^1.2.0"
       },
       "engines": {
         "node": ">=10.19.0"
@@ -5563,6 +5630,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -5648,12 +5725,16 @@
       }
     },
     "node_modules/lowercase-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-4.0.1.tgz",
+      "integrity": "sha512-wI9Nui/L8VfADa/cr/7NQruaASk1k23/Uh1khQ02BCVYiiy8F4AhOGnQzJy3Fl/c44GnYSbZHv8g7EcG3kJ1Qg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lru-cache": {
@@ -5756,27 +5837,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5787,12 +5847,16 @@
       }
     },
     "node_modules/mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/minimatch": {
@@ -5933,12 +5997,13 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.1.1.tgz",
+      "integrity": "sha512-JYc0DPlpGWB40kH5g07gGTrYuMqV653k3uBKY6uITPWds3M0ov3GaWGp9lbE3Bzngx8+XkfzgvASb9vk9JDFXQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5995,15 +6060,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/p-cancelable": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -6304,22 +6360,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
-    },
-    "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6386,6 +6426,7 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6452,7 +6493,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
       "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
@@ -6494,12 +6536,29 @@
       }
     },
     "node_modules/responselike": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-4.0.2.tgz",
+      "integrity": "sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "lowercase-keys": "^2.0.0"
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/responselike/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6857,6 +6916,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -7129,6 +7201,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici-types": {
@@ -7415,7 +7500,7 @@
         "superstruct": "^2.0.2"
       },
       "devDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.13.3",
+        "@aptos-labs/ts-sdk": ">=7.2.0",
         "@mysten/sui": "^2.0.0",
         "@protobuf-ts/runtime": "^2.11.1",
         "@tsconfig/recommended": "^1.0.3",
@@ -7432,7 +7517,7 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@aptos-labs/ts-sdk": ">=1.13.3",
+        "@aptos-labs/ts-sdk": ">=7.2.0",
         "@mysten/sui": ">=2.0.0"
       },
       "peerDependenciesMeta": {

--- a/packages/clients/README.md
+++ b/packages/clients/README.md
@@ -46,16 +46,20 @@ This is so you don't leak your `GAS_ACCESS_KEY` to your end users, and to allow 
 To use gas station with a local signer:
 
 ```ts
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { fromB64 } from "@mysten/sui/utils";
+import { fromBase64 } from "@mysten/sui/utils";
 import {
   GasStationClient,
   buildGaslessTransaction,
 } from "@shinami/clients/sui";
 
 // Use any Sui RPC provider of your choice. It MUST target the same network as GAS_ACCESS_KEY.
-const sui = new SuiClient({ url: getFullnodeUrl("testnet") });
+// SuiGrpcClient, SuiJsonRpcClient, and SuiGraphQLClient are all supported here.
+const sui = new SuiGrpcClient({
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+  network: "testnet",
+});
 // Obtain GAS_ACCESS_KEY from your Shinami web portal.
 const gas = new GasStationClient(GAS_ACCESS_KEY);
 
@@ -79,12 +83,12 @@ const { txBytes, signature: gasSignature } =
   await gas.sponsorTransaction(gaslessTx);
 
 // Sign the sponsored tx.
-const { signature } = await keypair.signTransaction(fromB64(txBytes));
+const { signature } = await keypair.signTransaction(fromBase64(txBytes));
 
 // Execute the sponsored & signed tx.
-const txResp = await sui.executeTransactionBlock({
-  transactionBlock: txBytes,
-  signature: [signature, gasSignature],
+const txResp = await sui.core.executeTransaction({
+  transaction: fromBase64(txBytes),
+  signatures: [signature, gasSignature],
 });
 ```
 
@@ -93,7 +97,7 @@ const txResp = await sui.executeTransactionBlock({
 To use the invisible wallet as a signer for a regular (non-sponsored) transaction:
 
 ```ts
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { Transaction } from "@mysten/sui/transactions";
 import {
   KeyClient,
@@ -102,7 +106,10 @@ import {
 } from "@shinami/clients/sui";
 
 // Use any Sui RPC provider of your choice.
-const sui = new SuiClient({ url: getFullnodeUrl("testnet") });
+const sui = new SuiGrpcClient({
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+  network: "testnet",
+});
 // Obtain WALLET_ACCESS_KEY from your Shinami web portal.
 const key = new KeyClient(WALLET_ACCESS_KEY);
 const wal = new WalletClient(WALLET_ACCESS_KEY);
@@ -127,16 +134,15 @@ const txBytes = await txb.build({ client: sui });
 const { signature } = await signer.signTransaction(txBytes);
 
 // Execute the signed tx.
-const txResp = await sui.executeTransactionBlock({
-  transactionBlock: txBytes,
-  signature,
+const txResp = await sui.core.executeTransaction({
+  transaction: txBytes,
+  signatures: [signature],
 });
 ```
 
 To use the invisible wallet to execute a gasless transaction, which seamlessly integrates with Shinami gas station:
 
 ```ts
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
 import {
   KeyClient,
   ShinamiWalletSigner,
@@ -144,8 +150,6 @@ import {
   buildGaslessTransaction,
 } from "@shinami/clients/sui";
 
-// Use any Sui RPC provider of your choice.
-const sui = new SuiClient({ url: getFullnodeUrl("testnet") });
 // Obtain SUPER_ACCESS_KEY from your Shinami web portal.
 // It MUST be authorized for all of these services:
 // - Gas station
@@ -171,47 +175,14 @@ const gaslessTx = await buildGaslessTransaction((txb) => {
 });
 
 // Execute the gasless tx using your invisible wallet.
-const txResp = await signer.executeGaslessTransaction(gaslessTx);
-```
-
-#### Beneficiary graph API
-
-Apps using Shinami invisible wallets can participate in [Bullshark Quests](https://quests.mystenlabs.com/) by allowing users to link their invisible wallets with self-custody wallets that own Bullshark NFTs, through the use of [beneficiary graph](https://github.com/shinamicorp/account-graph).
-
-```ts
-import {
-  EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
-  KeyClient,
-  ShinamiWalletSigner,
-  WalletClient,
-} from "@shinami/clients/sui";
-
-// Obtain SUPER_ACCESS_KEY from your Shinami web portal.
-// It MUST be authorized for all of these services:
-// - Gas station
-// - Wallet service
-const key = new KeyClient(SUPER_ACCESS_KEY);
-const wal = new WalletClient(SUPER_ACCESS_KEY);
-
-// WALLET_SECRET MUST be used consistently with this wallet id.
-// You are responsible for safe-keeping the (walletId, secret) pair.
-// Shinami cannot recover it for you.
-const signer = new ShinamiWalletSigner("my_wallet_id", wal, WALLET_SECRET, key);
-
-// Safe to do if unsure about the wallet's existence.
-await signer.tryCreate();
-
-// Use BULLSHARK_QUEST_BENEFICIARY_GRAPH_ID_MAINNET for Mainnet.
-const graphId = EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET;
-
-const txDigest = await signer.setBeneficiary(
-  graphId,
-  // Replace with user's actual wallet address that owns the Bullshark.
-  "0x1234",
-);
-
-// This should return the address we just set.
-const beneficiary = await signer.getBeneficiary(graphId);
+// Optionally pass a readMask (e.g. ["effects", "events"]) to control which fields are populated
+// in the response. Defaults to `["effects.status", "checkpoint"]` if omitted.
+const txResp = await signer.executeGaslessTransaction(gaslessTx, [
+  "effects",
+  "events",
+]);
+// txResp is shaped like the Sui gRPC `ExecuteTransactionResponse`:
+// txResp.transaction.effects.status.success, txResp.transaction.events.events[], etc.
 ```
 
 ### zkLogin wallet (Sui)

--- a/packages/clients/README.md
+++ b/packages/clients/README.md
@@ -333,7 +333,7 @@ const transaction = await aptos.transaction.build.simple({
 const accountAuthenticator = await signer.signTransaction(transaction);
 
 // Submit the tx for execution
-const pending = aptos.transaction.submit.simple({
+const pending = await aptos.transaction.submit.simple({
   transaction,
   senderAuthenticator: accountAuthenticator as AccountAuthenticatorEd25519,
 });
@@ -392,7 +392,7 @@ const transaction = await aptos.transaction.build.simple({
 });
 
 // Execute the gasless tx using your invisible wallet.
-const pending = signer.executeGaslessTransaction(transaction);
+const pending = await signer.executeGaslessTransaction(transaction);
 
 // Wait for it to be committed on-chain.
 const committed = await aptos.transaction.waitForTransaction({
@@ -520,7 +520,7 @@ const transaction = await movementClient.transaction.build.simple({
 const accountAuthenticator = await signer.signTransaction(transaction);
 
 // Submit the tx for execution
-const pending = movementClient.transaction.submit.simple({
+const pending = await movementClient.transaction.submit.simple({
   transaction,
   senderAuthenticator: accountAuthenticator as AccountAuthenticatorEd25519,
 });
@@ -579,7 +579,7 @@ const transaction = await movementClient.transaction.build.simple({
 });
 
 // Execute the gasless tx using your invisible wallet.
-const pending = signer.executeGaslessTransaction(transaction);
+const pending = await signer.executeGaslessTransaction(transaction);
 
 // Wait for it to be committed on-chain.
 const committed = await movementClient.transaction.waitForTransaction({

--- a/packages/clients/aptos/package.json
+++ b/packages/clients/aptos/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../dist/cjs/aptos/index.js"
-}

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -8,7 +8,6 @@
   },
   "files": [
     "dist",
-    "sui",
     "aptos"
   ],
   "type": "module",
@@ -19,8 +18,7 @@
       "require": "./dist/cjs/index.js"
     },
     "./sui": {
-      "import": "./dist/esm/sui/index.js",
-      "require": "./dist/cjs/sui/index.js"
+      "import": "./dist/esm/sui/index.js"
     },
     "./aptos": {
       "import": "./dist/esm/aptos/index.js",
@@ -65,7 +63,8 @@
   },
   "devDependencies": {
     "@aptos-labs/ts-sdk": ">=1.13.3",
-    "@mysten/sui": ">=1.0.4",
+    "@mysten/sui": "^2.0.0",
+    "@protobuf-ts/runtime": "^2.11.1",
     "@tsconfig/recommended": "^1.0.3",
     "@types/uuid": "^9.0.2",
     "eslint": "^8.57.0",
@@ -78,7 +77,7 @@
   },
   "peerDependencies": {
     "@aptos-labs/ts-sdk": ">=1.13.3",
-    "@mysten/sui": ">=1.0.4"
+    "@mysten/sui": ">=2.0.0"
   },
   "peerDependenciesMeta": {
     "@aptos-labs/ts-sdk": {

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -74,8 +74,8 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": ">=7.2.0",
-    "@mysten/sui": ">=2.0.0"
+    "@aptos-labs/ts-sdk": "^7.2.0",
+    "@mysten/sui": "^2.0.0"
   },
   "peerDependenciesMeta": {
     "@aptos-labs/ts-sdk": {

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -4,7 +4,7 @@
   "description": "TypeScript clients for Shinami services",
   "sideEffects": false,
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "files": [
     "dist",

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -60,7 +60,7 @@
     "superstruct": "^2.0.2"
   },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": ">=7.2.0",
+    "@aptos-labs/ts-sdk": "^7.2.0",
     "@mysten/sui": "^2.0.0",
     "@protobuf-ts/runtime": "^2.11.1",
     "@tsconfig/recommended": "^1.0.3",

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -7,8 +7,7 @@
     "node": ">=22"
   },
   "files": [
-    "dist",
-    "aptos"
+    "dist"
   ],
   "type": "module",
   "main": "dist/cjs/index.js",
@@ -21,8 +20,7 @@
       "import": "./dist/esm/sui/index.js"
     },
     "./aptos": {
-      "import": "./dist/esm/aptos/index.js",
-      "require": "./dist/cjs/aptos/index.js"
+      "import": "./dist/esm/aptos/index.js"
     }
   },
   "scripts": {
@@ -62,7 +60,7 @@
     "superstruct": "^2.0.2"
   },
   "devDependencies": {
-    "@aptos-labs/ts-sdk": ">=1.13.3",
+    "@aptos-labs/ts-sdk": ">=7.2.0",
     "@mysten/sui": "^2.0.0",
     "@protobuf-ts/runtime": "^2.11.1",
     "@tsconfig/recommended": "^1.0.3",
@@ -76,7 +74,7 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": ">=1.13.3",
+    "@aptos-labs/ts-sdk": ">=7.2.0",
     "@mysten/sui": ">=2.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/clients/package.json
+++ b/packages/clients/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinami/clients",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "TypeScript clients for Shinami services",
   "sideEffects": false,
   "engines": {

--- a/packages/clients/src/region.ts
+++ b/packages/clients/src/region.ts
@@ -11,8 +11,9 @@ export function createRegionalApiUrl(
   region: Region,
   chain: Chain,
   service: string,
+  version = "v1",
 ): string {
-  return `https://api.${region}.shinami.com/${chain}/${service}/v1`;
+  return `https://api.${region}.shinami.com/${chain}/${service}/${version}`;
 }
 
 export function inferRegionalValueFromAccessKey<

--- a/packages/clients/src/sui/endpoints.ts
+++ b/packages/clients/src/sui/endpoints.ts
@@ -10,7 +10,7 @@ export const GasStationRpcUrls = {
 } as const satisfies Partial<Record<Region, string>>;
 
 export const WalletRpcUrls = {
-  us1: createRegionalApiUrl("us1", "sui", "wallet"),
+  us1: createRegionalApiUrl("us1", "sui", "wallet", "v2"),
 } as const satisfies Partial<Record<Region, string>>;
 
 export const KeyRpcUrls = {

--- a/packages/clients/src/sui/gas.ts
+++ b/packages/clients/src/sui/gas.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SuiClient } from "@mysten/sui/client";
+import { ClientWithCoreApi } from "@mysten/sui/client";
 import { Transaction } from "@mysten/sui/transactions";
-import { toB64 } from "@mysten/sui/utils";
+import { toBase64 } from "@mysten/sui/utils";
 import { Infer, enums, number, object, optional, string } from "superstruct";
 import { ShinamiRpcClient, trimTrailingParams } from "../rpc.js";
 import { throwExpression } from "../utils.js";
@@ -170,7 +170,7 @@ export class GasStationClient extends ShinamiRpcClient {
  *    - sender - Optional sender address. Can also be set in the transaction data.
  *    - gasBudget - Optional gas budget. Can also be set in the transaction data.
  *    - gasPrice - Optional gas price. Can also be set in the transaction data.
- *    - sui - `SuiClient`. Required if the transaction uses non fully resolved inputs.
+ *    - sui - `ClientWithCoreApi`. Required if the transaction uses non fully resolved inputs.
  * @returns A gasless transaction to be sponsored.
  */
 export async function buildGaslessTransaction(
@@ -179,7 +179,7 @@ export async function buildGaslessTransaction(
     sender?: string;
     gasBudget?: number | string;
     gasPrice?: number | string;
-    sui?: SuiClient;
+    sui?: ClientWithCoreApi;
   },
 ): Promise<GaslessTransaction> {
   let tx: Transaction;
@@ -192,7 +192,7 @@ export async function buildGaslessTransaction(
   const txData = tx.getData();
 
   return {
-    txKind: toB64(
+    txKind: toBase64(
       await tx.build({ client: options?.sui, onlyTransactionKind: true }),
     ),
     sender: options?.sender ?? txData.sender ?? undefined,

--- a/packages/clients/src/sui/utils.ts
+++ b/packages/clients/src/sui/utils.ts
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fromB64, fromHEX, toB64, toHEX } from "@mysten/sui/utils";
+import { fromBase64, fromHex, toBase64, toHex } from "@mysten/sui/utils";
 
 export function bigIntToBase64(n: bigint): string {
-  return toB64(fromHEX(n.toString(16)));
+  return toBase64(fromHex(n.toString(16)));
 }
 
 export function base64ToBigInt(s: string): bigint {
-  return BigInt(`0x${toHEX(fromB64(s))}`);
+  return BigInt(`0x${toHex(fromBase64(s))}`);
 }

--- a/packages/clients/src/sui/wallet.ts
+++ b/packages/clients/src/sui/wallet.ts
@@ -3,14 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  ExecuteTransactionRequestType,
-  SuiTransactionBlockResponse,
-  SuiTransactionBlockResponseOptions,
-} from "@mysten/sui/client";
-import { toB64 } from "@mysten/sui/utils";
+import { GrpcTypes } from "@mysten/sui/grpc";
+import { toBase64 } from "@mysten/sui/utils";
 import { JSONRPCError } from "@open-rpc/client-js";
-import { Infer, nullable, object, string } from "superstruct";
+import { JsonValue } from "@protobuf-ts/runtime";
+import { Infer, object, string } from "superstruct";
 import { ShinamiRpcClient, errorDetails, trimTrailingParams } from "../rpc.js";
 import { GaslessTransaction } from "./gas.js";
 import { KeyRpcUrls, WalletRpcUrls } from "./endpoints.js";
@@ -109,7 +106,7 @@ export class WalletClient extends ShinamiRpcClient {
     sessionToken: string,
     txBytes: string | Uint8Array,
   ): Promise<SignTransactionResult> {
-    if (txBytes instanceof Uint8Array) txBytes = toB64(txBytes);
+    if (txBytes instanceof Uint8Array) txBytes = toBase64(txBytes);
     return this.request(
       "shinami_wal_signTransactionBlock",
       [walletId, sessionToken, txBytes],
@@ -131,7 +128,7 @@ export class WalletClient extends ShinamiRpcClient {
     message: string | Uint8Array,
     wrapBcs = true,
   ): Promise<string> {
-    if (message instanceof Uint8Array) message = toB64(message);
+    if (message instanceof Uint8Array) message = toBase64(message);
     return this.request(
       "shinami_wal_signPersonalMessage",
       [walletId, sessionToken, message, wrapBcs],
@@ -146,20 +143,26 @@ export class WalletClient extends ShinamiRpcClient {
    * - Wallet Service
    * - Gas Station
    *
+   * Note this call itself is still JSON-RPC like every other method on this client. The Shinami
+   * backend now sponsors and executes this transaction against a Sui node over gRPC, and forwards
+   * that gRPC response back to you. The raw wire transport for this call is JSON, but the result
+   * is converted back into Sui's native gRPC `ExecuteTransactionResponse` representation before
+   * being returned.
+   *
    * @param walletId Wallet id.
    * @param sessionToken Session token, obtained by `KeyClient.createSession`.
    * @param tx Gasless transaction.
-   * @param options Transaction execution response options.
-   * @param requestType Transaction execution request type.
-   * @returns Transaction execution response.
+   * @param readMask Field mask paths specifying which fields to read in the response. Defaults to
+   *    `effects.status,checkpoint` if omitted.
+   * @returns Transaction execution response, matching Sui's native gRPC
+   *    `ExecuteTransactionResponse`.
    */
   executeGaslessTransaction(
     walletId: string,
     sessionToken: string,
     tx: Omit<GaslessTransaction, "sender">,
-    options?: SuiTransactionBlockResponseOptions,
-    requestType?: ExecuteTransactionRequestType,
-  ): Promise<SuiTransactionBlockResponse> {
+    readMask?: string[],
+  ): Promise<GrpcTypes.ExecuteTransactionResponse> {
     return this.request(
       "shinami_wal_executeGaslessTransactionBlock",
       trimTrailingParams([
@@ -167,87 +170,11 @@ export class WalletClient extends ShinamiRpcClient {
         sessionToken,
         tx.txKind,
         tx.gasBudget,
-        options,
-        requestType,
         tx.gasPrice,
+        readMask,
       ]),
-      /* Not validating result because it's from Sui node */
-    );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Designates a beneficiary account for this wallet in the specified beneficiary graph instance.
-   * Calling this method multiple times will override the previous designations.
-   *
-   * Apps participating in Bullshark Quests can use this method to link up Shinami invisible wallets
-   * with their users' self-custody wallets.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * - Gas Station
-   * @param walletId Wallet id.
-   * @param sessionToken Session token, obtained by `KeyClient.createSession`.
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @param beneficiaryAddress Beneficiary address.
-   * @returns Transaction digest for this operation.
-   */
-  setBeneficiary(
-    walletId: string,
-    sessionToken: string,
-    beneficiaryGraphId: string,
-    beneficiaryAddress: string,
-  ): Promise<string> {
-    return this.request(
-      "shinami_walx_setBeneficiary",
-      [walletId, sessionToken, beneficiaryGraphId, beneficiaryAddress],
-      string(),
-    );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Clears any beneficiary designation for this wallet in the specified beneficiary graph instance.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * - Gas Station
-   * @param walletId Wallet id.
-   * @param sessionToken Session token, obtained by `KeyClient.createSession`.
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @returns Transaction digest for this operation.
-   */
-  unsetBeneficiary(
-    walletId: string,
-    sessionToken: string,
-    beneficiaryGraphId: string,
-  ): Promise<string> {
-    return this.request(
-      "shinami_walx_unsetBeneficiary",
-      [walletId, sessionToken, beneficiaryGraphId],
-      string(),
-    );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Gets the beneficiary designation for this wallet in the specified beneficiary graph instance.
-   * This is a convenience method on top of suix_getDynamicFieldObject.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * @param walletId Wallet id.
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @returns Beneficiary address, or null if no beneficiary is designated.
-   */
-  getBeneficiary(
-    walletId: string,
-    beneficiaryGraphId: string,
-  ): Promise<string | null> {
-    return this.request(
-      "shinami_walx_getBeneficiary",
-      [walletId, beneficiaryGraphId],
-      nullable(string()),
+    ).then((raw) =>
+      GrpcTypes.ExecuteTransactionResponse.fromJson(raw as JsonValue),
     );
   }
 }
@@ -422,101 +349,25 @@ export class ShinamiWalletSigner {
    * - Wallet Service
    * - Gas Station
    *
+   * See `WalletClient.executeGaslessTransaction` for details.
+   *
    * @param tx Gasless transaction.
-   * @param options Transaction execution response options.
-   * @param requestType Transaction execution request type.
-   * @returns Transaction execution response.
+   * @param readMask Field mask paths specifying which fields to read in the response. Defaults to
+   *    `effects.status,checkpoint` if omitted.
+   * @returns Transaction execution response, shaped like Sui's native gRPC
+   *    `ExecuteTransactionResponse`.
    */
   executeGaslessTransaction(
     tx: Omit<GaslessTransaction, "sender">,
-    options?: SuiTransactionBlockResponseOptions,
-    requestType?: ExecuteTransactionRequestType,
-  ): Promise<SuiTransactionBlockResponse> {
+    readMask?: string[],
+  ): Promise<GrpcTypes.ExecuteTransactionResponse> {
     return this.session.withToken((token) =>
       this.walletClient.executeGaslessTransaction(
         this.walletId,
         token,
         tx,
-        options,
-        requestType,
+        readMask,
       ),
     );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Designates a beneficiary account for this wallet in the specified beneficiary graph instance.
-   * Calling this method multiple times will override the previous designations.
-   *
-   * Apps participating in Bullshark Quests can use this method to link up Shinami invisible wallets
-   * with their users' self-custody wallets.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * - Gas Station
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @param beneficiaryAddress Beneficiary address.
-   * @returns Transaction digest for this operation.
-   */
-  setBeneficiary(
-    beneficiaryGraphId: string,
-    beneficiaryAddress: string,
-  ): Promise<string> {
-    return this.session.withToken((token) =>
-      this.walletClient.setBeneficiary(
-        this.walletId,
-        token,
-        beneficiaryGraphId,
-        beneficiaryAddress,
-      ),
-    );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Clears any beneficiary designation for this wallet in the specified beneficiary graph instance.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * - Gas Station
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @returns Transaction digest for this operation.
-   */
-  unsetBeneficiary(beneficiaryGraphId: string): Promise<string> {
-    return this.session.withToken((token) =>
-      this.walletClient.unsetBeneficiary(
-        this.walletId,
-        token,
-        beneficiaryGraphId,
-      ),
-    );
-  }
-
-  /**
-   * [Beneficiary Graph API]
-   * Gets the beneficiary designation for this wallet in the specified beneficiary graph instance.
-   * This is a convenience method on top of suix_getDynamicFieldObject.
-   *
-   * To call this method, your access key must be authorized for all of these Shinami services:
-   * - Wallet Service
-   * @param beneficiaryGraphId Id of the beneficiary graph instance.
-   * @returns Beneficiary address, or null if no beneficiary is designated.
-   */
-  getBeneficiary(beneficiaryGraphId: string): Promise<string | null> {
-    return this.walletClient.getBeneficiary(this.walletId, beneficiaryGraphId);
   }
 }
-
-/**
- * Offical beneficiary graph id recognized by the Bullshark Quests for point tracking.
- * Must be used with a Mainnet access key.
- */
-export const BULLSHARK_QUEST_BENEFICIARY_GRAPH_ID_MAINNET =
-  "0x39fabecb3e74036e6140a938fd1cb194a1affd086004e93c4a76af59d64a2c76";
-
-/**
- * Example beneficiary graph id published on Testnet.
- * Must be used with a Testnet access key.
- */
-export const EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET =
-  "0x1987692739e70cea40e5f2596eee2ebe00bde830f72bb76a7187a0d6d4cea278";

--- a/packages/clients/sui/package.json
+++ b/packages/clients/sui/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../dist/cjs/sui/index.js"
-}

--- a/packages/clients/test/sui/gas.integration.test.ts
+++ b/packages/clients/test/sui/gas.integration.test.ts
@@ -5,14 +5,17 @@
 
 import { beforeAll, describe, expect, it } from "@jest/globals";
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { fromB64 } from "@mysten/sui/utils";
-import { SuiClient, getFullnodeUrl } from "@mysten/sui/client";
+import { fromBase64 } from "@mysten/sui/utils";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import { buildGaslessTransaction } from "../../src/sui/index.js";
 import { EXAMPLE_PACKAGE_ID, createGasClient } from "./integration.env.js";
 import { Transaction } from "@mysten/sui/transactions";
 
 // Integration tests by default target Sui Testnet.
-const sui = new SuiClient({ url: getFullnodeUrl("testnet") });
+const sui = new SuiGrpcClient({
+  baseUrl: "https://fullnode.testnet.sui.io:443",
+  network: "testnet",
+});
 const gas = createGasClient();
 
 const keypair = new Ed25519Keypair();
@@ -50,31 +53,23 @@ describe("GasStationClient", () => {
     );
 
     const signedTx = await keypair.signTransaction(
-      fromB64(sponsoredTx.txBytes),
+      fromBase64(sponsoredTx.txBytes),
     );
     expect(signedTx.bytes).toBe(sponsoredTx.txBytes);
 
-    const txResp = await sui.executeTransactionBlock({
-      transactionBlock: signedTx.bytes,
-      signature: [signedTx.signature, sponsoredTx.signature],
-      options: {
-        showEffects: true,
-        showEvents: true,
-      },
+    const txResp = await sui.core.executeTransaction({
+      transaction: fromBase64(signedTx.bytes),
+      signatures: [signedTx.signature, sponsoredTx.signature],
+      include: { effects: true, events: true },
     });
-    console.log("txResp", txResp);
-    expect(txResp).toMatchObject({
-      effects: {
-        status: {
-          status: "success",
-        },
-      },
+    const tx = txResp.Transaction ?? txResp.FailedTransaction;
+    console.log("tx", tx);
+    expect(tx).toMatchObject({
+      status: { success: true },
       events: [
         {
-          type: `${EXAMPLE_PACKAGE_ID}::math::AddResult`,
-          parsedJson: {
-            result: "3",
-          },
+          eventType: `${EXAMPLE_PACKAGE_ID}::math::AddResult`,
+          json: { result: "3" },
         },
       ],
     });

--- a/packages/clients/test/sui/utils.unit.test.ts
+++ b/packages/clients/test/sui/utils.unit.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2023-2024 Shinami Corp.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from "@jest/globals";
+import { base64ToBigInt, bigIntToBase64 } from "../../src/sui/utils.js";
+
+describe("bigIntToBase64 / base64ToBigInt", () => {
+  it("round-trips a large bigint", () => {
+    const n = BigInt("123456789012345678901234567890");
+    expect(base64ToBigInt(bigIntToBase64(n))).toBe(n);
+  });
+
+  it("round-trips zero", () => {
+    const n = BigInt(0);
+    expect(base64ToBigInt(bigIntToBase64(n))).toBe(n);
+  });
+});

--- a/packages/clients/test/sui/wallet.integration.test.ts
+++ b/packages/clients/test/sui/wallet.integration.test.ts
@@ -10,7 +10,6 @@ import {
 } from "@mysten/sui/verify";
 import { v4 as uuidv4 } from "uuid";
 import {
-  EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
   KeySession,
   ShinamiWalletSigner,
   buildGaslessTransaction,
@@ -90,25 +89,41 @@ describe("ShinamiWallet", () => {
         },
         { gasBudget, gasPrice },
       );
-      const txResp = await signer3.executeGaslessTransaction(gaslessTx, {
-        showEffects: true,
-        showEvents: true,
-      });
+      const txResp = await signer3.executeGaslessTransaction(gaslessTx, [
+        "effects",
+        "events",
+      ]);
       console.log("txResp", txResp);
       expect(txResp).toMatchObject({
-        effects: {
-          status: {
-            status: "success",
-          },
-        },
-        events: [
-          {
-            type: `${EXAMPLE_PACKAGE_ID}::math::AddResult`,
-            parsedJson: {
-              result: (x + y).toString(),
+        transaction: {
+          effects: {
+            status: {
+              success: true,
             },
           },
-        ],
+          events: {
+            events: [
+              {
+                eventType: `${EXAMPLE_PACKAGE_ID}::math::AddResult`,
+                json: {
+                  kind: {
+                    oneofKind: "structValue",
+                    structValue: {
+                      fields: {
+                        result: {
+                          kind: {
+                            oneofKind: "stringValue",
+                            stringValue: (x + y).toString(),
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
       });
     };
 
@@ -123,43 +138,4 @@ describe("ShinamiWallet", () => {
     executeAddTx(3, 4),
     30_000,
   );
-
-  it("sets a beneficiary address and gets it back", async () => {
-    const beneficiary =
-      "0x0000000000000000000000000000000000000000000000000000000000001111";
-    const txDigest = await signer.setBeneficiary(
-      EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
-      beneficiary,
-    );
-    console.log("txDigest", txDigest);
-
-    await expect(
-      signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),
-    ).resolves.toBe(beneficiary);
-  }, 30_000);
-
-  it("sets another beneficiary address and gets it back", async () => {
-    const beneficiary =
-      "0x0000000000000000000000000000000000000000000000000000000000002222";
-    const txDigest = await signer.setBeneficiary(
-      EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
-      beneficiary,
-    );
-    console.log("txDigest", txDigest);
-
-    await expect(
-      signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),
-    ).resolves.toBe(beneficiary);
-  }, 30_000);
-
-  it("unsets beneficiary address", async () => {
-    const txDigest = await signer.unsetBeneficiary(
-      EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET,
-    );
-    console.log("txDigest", txDigest);
-
-    await expect(
-      signer.getBeneficiary(EXAMPLE_BENEFICIARY_GRAPH_ID_TESTNET),
-    ).resolves.toBe(null);
-  }, 30_000);
 });

--- a/packages/nextjs-zklogin/client/package.json
+++ b/packages/nextjs-zklogin/client/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../dist/cjs/client/index.js"
-}

--- a/packages/nextjs-zklogin/package.json
+++ b/packages/nextjs-zklogin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shinami/nextjs-zklogin",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Next.js SDK for integrating with Sui zkLogin",
   "sideEffects": false,
   "engines": {

--- a/packages/nextjs-zklogin/package.json
+++ b/packages/nextjs-zklogin/package.json
@@ -7,38 +7,28 @@
     "node": ">=20"
   },
   "files": [
-    "dist",
-    "client",
-    "server"
+    "dist"
   ],
   "type": "module",
-  "main": "./dist/cjs/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "import": "./dist/esm/index.js"
     },
     "./client": {
-      "import": "./dist/esm/client/index.js",
-      "require": "./dist/cjs/client/index.js"
+      "import": "./dist/esm/client/index.js"
     },
     "./server": {
-      "import": "./dist/esm/server/index.js",
-      "require": "./dist/cjs/server/index.js"
+      "import": "./dist/esm/server/index.js"
     },
     "./server/pages": {
-      "import": "./dist/esm/server/pages/index.js",
-      "require": "./dist/cjs/server/pages/index.js"
+      "import": "./dist/esm/server/pages/index.js"
     },
     "./server/pages/utils": {
-      "import": "./dist/esm/server/pages/utils.js",
-      "require": "./dist/cjs/server/pages/utils.js"
+      "import": "./dist/esm/server/pages/utils.js"
     }
   },
   "scripts": {
-    "build": "npm run build:cjs && npm run build:esm",
-    "build:cjs": "tsc --build tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > dist/cjs/package.json",
-    "build:esm": "tsc --build",
+    "build": "tsc --build",
     "lint": "eslint .",
     "clean": "rm -fr ./dist ./coverage"
   },
@@ -64,13 +54,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@mysten/zklogin": "^0.7.4",
     "@shinami/clients": "^0.11.0",
     "@tanstack/react-query": "^5.0.5",
     "iron-session": "^6.3.1",
+    "jose": "^6.2.3",
     "superstruct": "^2.0.2"
   },
   "devDependencies": {
+    "@mysten/sui": ">=2.0.0",
     "@tsconfig/recommended": "^1.0.3",
     "@types/react": "^18.2.31",
     "eslint": "^8.57.0",
@@ -78,6 +69,7 @@
     "typescript-eslint": "^7.7.1"
   },
   "peerDependencies": {
+    "@mysten/sui": ">=2.0.0",
     "next": ">=13"
   }
 }

--- a/packages/nextjs-zklogin/package.json
+++ b/packages/nextjs-zklogin/package.json
@@ -4,7 +4,7 @@
   "description": "Next.js SDK for integrating with Sui zkLogin",
   "sideEffects": false,
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "files": [
     "dist"
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@shinami/clients": "^0.11.0",
+    "@shinami/clients": "^0.12.0",
     "@tanstack/react-query": "^5.0.5",
     "iron-session": "^6.3.1",
     "jose": "^6.2.3",

--- a/packages/nextjs-zklogin/server/package.json
+++ b/packages/nextjs-zklogin/server/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../dist/cjs/server/index.js"
-}

--- a/packages/nextjs-zklogin/server/pages/package.json
+++ b/packages/nextjs-zklogin/server/pages/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../../dist/cjs/server/pages/index.js"
-}

--- a/packages/nextjs-zklogin/server/pages/utils/package.json
+++ b/packages/nextjs-zklogin/server/pages/utils/package.json
@@ -1,5 +1,0 @@
-{
-  "private": true,
-  "sideEffects": false,
-  "main": "../../../dist/cjs/server/pages/utils.js"
-}

--- a/packages/nextjs-zklogin/src/client/components/login.tsx
+++ b/packages/nextjs-zklogin/src/client/components/login.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SuiClient } from "@mysten/sui/client";
+import { ClientWithCoreApi } from "@mysten/sui/client";
 import React, { FunctionComponent, useEffect, useState } from "react";
 import { AUTH_API_BASE } from "../../env.js";
 import { useNewZkLoginSession } from "../hooks/login.js";
@@ -49,19 +49,20 @@ export function withNewZkLoginSession<P extends object>(
 /**
  * Helper function to calculate a epoch relative to the current one.
  *
- * The current epoch is retrieved using `SuiClient`.
+ * The current epoch is retrieved using a `ClientWithCoreApi` (e.g. `SuiJsonRpcClient`,
+ * `SuiGrpcClient`, or `SuiGraphQLClient`).
  *
- * @param sui The `SuiClient`.
+ * @param sui The `ClientWithCoreApi`.
  * @param epochsBeyondCurrent The number of epochs beyond the current one.
  *    Defaults to 1, i.e. the next epoch.
  * @returns Epoch number.
  */
 export async function relativeToCurrentEpoch(
-  sui: SuiClient,
+  sui: ClientWithCoreApi,
   epochsBeyondCurrent = 1,
 ): Promise<number> {
-  const { epoch } = await sui.getLatestSuiSystemState();
-  return Number(epoch) + epochsBeyondCurrent;
+  const { systemState } = await sui.core.getCurrentSystemState();
+  return Number(systemState.epoch) + epochsBeyondCurrent;
 }
 
 /**

--- a/packages/nextjs-zklogin/src/client/components/login.tsx
+++ b/packages/nextjs-zklogin/src/client/components/login.tsx
@@ -49,8 +49,8 @@ export function withNewZkLoginSession<P extends object>(
 /**
  * Helper function to calculate a epoch relative to the current one.
  *
- * The current epoch is retrieved using a `ClientWithCoreApi` (e.g. `SuiJsonRpcClient`,
- * `SuiGrpcClient`, or `SuiGraphQLClient`).
+ * The current epoch is retrieved using a transport-agnostic `ClientWithCoreApi`
+ * (e.g. `SuiJsonRpcClient`, `SuiGrpcClient`, or `SuiGraphQLClient`).
  *
  * @param sui The `ClientWithCoreApi`.
  * @param epochsBeyondCurrent The number of epochs beyond the current one.

--- a/packages/nextjs-zklogin/src/client/hooks/login.ts
+++ b/packages/nextjs-zklogin/src/client/hooks/login.ts
@@ -4,7 +4,7 @@
  */
 
 import { Ed25519Keypair } from "@mysten/sui/keypairs/ed25519";
-import { generateNonce, generateRandomness } from "@mysten/zklogin";
+import { generateNonce, generateRandomness } from "@mysten/sui/zklogin";
 import { UseMutationResult, useMutation } from "@tanstack/react-query";
 import { useLogout } from "./api.js";
 import { ZkLoginLocalSession, useSaveZkLoginLocalSession } from "./session.js";

--- a/packages/nextjs-zklogin/src/client/hooks/tx.ts
+++ b/packages/nextjs-zklogin/src/client/hooks/tx.ts
@@ -4,7 +4,7 @@
  */
 
 import { Keypair } from "@mysten/sui/cryptography";
-import { fromB64 } from "@mysten/sui/utils";
+import { fromBase64 } from "@mysten/sui/utils";
 import { MutationFunction } from "@tanstack/react-query";
 import { Struct } from "superstruct";
 import { PreparedTransactionBytes, SignedTransactionBytes } from "../../tx.js";
@@ -43,7 +43,7 @@ export function apiTxExecMutationFn<
       resultSchema: PreparedTransactionBytes,
     })(params, ...rest);
     const { signature } = await params.keyPair.signTransaction(
-      fromB64(tx.txBytes),
+      fromBase64(tx.txBytes),
     );
     return await apiMutationFn<T, SignedTransactionBytes>({
       uri: () => `${uri}/exec`,

--- a/packages/nextjs-zklogin/src/server/pages/auth/index.ts
+++ b/packages/nextjs-zklogin/src/server/pages/auth/index.ts
@@ -24,7 +24,7 @@ import { me } from "./me.js";
  * API routes at `/api/auth/login`, `/api/auth/logout`, `/api/auth/me`, `/api/auth/apple`. If you
  * wish to install this under another API route, you must set env `NEXT_PUBLIC_AUTH_API_BASE`.
  *
- * @param epochProvider Function to fetch the current epoch number. Can also use a `SuiClient`.
+ * @param epochProvider Function to fetch the current epoch number. Can also use a `ClientWithCoreApi`.
  * @param saltProvider Function to fetch the wallet salt. Can also use a `ZkWalletClient`.
  * @param zkProofProvider Function to generate a zkProof. Can also use a `ZkProverClient`.
  * @param allowedApps OAuth application ids allowed for login.

--- a/packages/nextjs-zklogin/src/server/pages/auth/login.ts
+++ b/packages/nextjs-zklogin/src/server/pages/auth/login.ts
@@ -4,10 +4,10 @@
  */
 
 import {
-  computeZkLoginAddress,
+  computeZkLoginAddressFromSeed,
   genAddressSeed,
   generateNonce,
-} from "@mysten/zklogin";
+} from "@mysten/sui/zklogin";
 import { withIronSessionApiRoute } from "iron-session/next";
 import { jwtVerify } from "jose";
 import { NextApiHandler, NextApiRequest } from "next";
@@ -116,19 +116,17 @@ async function getZkLoginUser<T>(
     keyClaimName: body.keyClaimName,
     subWallet: 0, // TODO - expose additional sub-wallets.
   });
-  const wallet = computeZkLoginAddress({
-    claimName: body.keyClaimName,
-    claimValue: keyClaimValue,
-    iss,
-    aud,
-    userSalt: salt,
-  });
-  const addressSeed = genAddressSeed(
+  const addressSeedBigInt = genAddressSeed(
     salt,
     body.keyClaimName,
     keyClaimValue,
     aud,
-  ).toString();
+  );
+
+  // Using computeZkLoginAddressFromSeed from `@mysten/sui/zklogin` requires `legacyAddress: true`
+  // to generate consistent addresses from the prior version.
+  const wallet = computeZkLoginAddressFromSeed(addressSeedBigInt, iss, true);
+  const addressSeed = addressSeedBigInt.toString();
   const partialProof = await getZkProof(zkProofProvider, {
     jwt: body.jwt,
     ephemeralPublicKey: publicKeyFromBase64(body.extendedEphemeralPublicKey),

--- a/packages/nextjs-zklogin/src/server/pages/tx.ts
+++ b/packages/nextjs-zklogin/src/server/pages/tx.ts
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  SuiClient,
-  SuiTransactionBlockResponse,
-  SuiTransactionBlockResponseOptions,
-} from "@mysten/sui/client";
+import { ClientWithCoreApi, SuiClientTypes } from "@mysten/sui/client";
+import { fromBase64 } from "@mysten/sui/utils";
 import { GasStationClient, GaslessTransaction } from "@shinami/clients/sui";
 import { NextApiHandler, NextApiRequest } from "next";
 import { validate } from "superstruct";
@@ -29,9 +26,13 @@ export type TransactionBytesBuilder<TAuth = unknown> = (
   user: ZkLoginUser<TAuth>,
 ) => Promise<string> | string;
 
-export type TransactionResponseParser<TAuth = unknown, TRes = unknown> = (
+export type TransactionResponseParser<
+  TAuth = unknown,
+  TRes = unknown,
+  Include extends SuiClientTypes.TransactionInclude = object,
+> = (
   req: NextApiRequest,
-  txRes: SuiTransactionBlockResponse,
+  txRes: SuiClientTypes.Transaction<Include>,
   user: ZkLoginUser<TAuth>,
 ) => Promise<TRes> | TRes;
 
@@ -79,10 +80,14 @@ function sponsoredTxHandler<TAuth = unknown>(
   });
 }
 
-function execHandler<TAuth = unknown, TRes = unknown>(
-  sui: SuiClient,
-  parseTxRes: TransactionResponseParser<TAuth, TRes>,
-  txOptions: SuiTransactionBlockResponseOptions = {},
+function execHandler<
+  TAuth = unknown,
+  TRes = unknown,
+  Include extends SuiClientTypes.TransactionInclude = object,
+>(
+  sui: ClientWithCoreApi,
+  parseTxRes: TransactionResponseParser<TAuth, TRes, Include>,
+  txInclude: Include = {} as Include,
 ): NextApiHandler<TRes | ApiErrorBody> {
   return methodDispatcher({
     POST: async (req, res) => {
@@ -94,22 +99,23 @@ function execHandler<TAuth = unknown, TRes = unknown>(
       const user = req.session.user! as ZkLoginUser<TAuth>;
       const zkSignature = assembleZkLoginSignature(user, body.signature);
 
-      const txRes = await sui.executeTransactionBlock({
-        transactionBlock: body.txBytes,
-        signature: body.gasSignature
+      const txRes = await sui.core.executeTransaction({
+        transaction: fromBase64(body.txBytes),
+        signatures: body.gasSignature
           ? [zkSignature, body.gasSignature]
-          : zkSignature,
-        options: { ...txOptions, showEffects: true },
+          : [zkSignature],
+        include: txInclude,
       });
+      const tx = txRes.Transaction ?? txRes.FailedTransaction;
 
-      if (txRes.effects?.status.status !== "success") {
+      if (!tx.status.success) {
         console.error("Tx execution failed", txRes);
         return res.status(500).json({
-          error: `Tx execution failed: ${txRes.effects?.status.error}`,
+          error: `Tx execution failed: ${tx.status.error.message}`,
         });
       }
 
-      res.json(await parseTxRes(req, txRes, user));
+      res.json(await parseTxRes(req, tx, user));
     },
   });
 }
@@ -122,23 +128,27 @@ function execHandler<TAuth = unknown, TRes = unknown>(
  * - [base_route]/exec for executing the transaction after signed by frontend, and parsing the
  *   transaction response.
  *
- * @param sui `SuiClient` for transaction building and execution.
+ * @param sui `ClientWithCoreApi` for transaction building and execution.
  * @param buildTxBytes Function to build a transaction (encoded in Base64).
  * @param parseTxRes Function to parse the transaction response.
- * @param txOptions Transaction response options.
+ * @param txInclude Fields to include in the transaction response.
  * @returns A Next.js API route handler.
  */
-export function zkLoginTxExecHandler<TAuth = unknown, TRes = unknown>(
-  sui: SuiClient,
+export function zkLoginTxExecHandler<
+  TAuth = unknown,
+  TRes = unknown,
+  Include extends SuiClientTypes.TransactionInclude = object,
+>(
+  sui: ClientWithCoreApi,
   buildTxBytes: TransactionBytesBuilder<TAuth>,
-  parseTxRes: TransactionResponseParser<TAuth, TRes>,
-  txOptions: SuiTransactionBlockResponseOptions = {},
+  parseTxRes: TransactionResponseParser<TAuth, TRes, Include>,
+  txInclude: Include = {} as Include,
 ): NextApiHandler {
   return withZkLoginUserRequired(
     sui,
     catchAllDispatcher({
       tx: txHandler(buildTxBytes),
-      exec: execHandler(sui, parseTxRes, txOptions),
+      exec: execHandler(sui, parseTxRes, txInclude),
     }),
   );
 }
@@ -151,25 +161,29 @@ export function zkLoginTxExecHandler<TAuth = unknown, TRes = unknown>(
  * - [base_route]/exec for executing the transaction after signed by frontend, and parsing the
  *   transaction response.
  *
- * @param sui `SuiClient` for transaction building and execution.
+ * @param sui `ClientWithCoreApi` for transaction building and execution.
  * @param gas `GasStationClient` for sponsoring transaction.
  * @param buildGaslessTx Function to build a gasless transaction.
  * @param parseTxRes Function to parse the transaction response.
- * @param txOptions Transaction response options.
+ * @param txInclude Fields to include in the transaction response.
  * @returns A Next.js API route handler.
  */
-export function zkLoginSponsoredTxExecHandler<TAuth = unknown, TRes = unknown>(
-  sui: SuiClient,
+export function zkLoginSponsoredTxExecHandler<
+  TAuth = unknown,
+  TRes = unknown,
+  Include extends SuiClientTypes.TransactionInclude = object,
+>(
+  sui: ClientWithCoreApi,
   gas: GasStationClient,
   buildGaslessTx: GaslessTransactionBuilder<TAuth>,
-  parseTxRes: TransactionResponseParser<TAuth, TRes>,
-  txOptions: SuiTransactionBlockResponseOptions = {},
+  parseTxRes: TransactionResponseParser<TAuth, TRes, Include>,
+  txInclude: Include = {} as Include,
 ): NextApiHandler {
   return withZkLoginUserRequired(
     sui,
     catchAllDispatcher({
       tx: sponsoredTxHandler(gas, buildGaslessTx),
-      exec: execHandler(sui, parseTxRes, txOptions),
+      exec: execHandler(sui, parseTxRes, txInclude),
     }),
   );
 }

--- a/packages/nextjs-zklogin/src/server/providers.ts
+++ b/packages/nextjs-zklogin/src/server/providers.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SuiClient } from "@mysten/sui/client";
+import { ClientWithCoreApi } from "@mysten/sui/client";
 import { PublicKey } from "@mysten/sui/cryptography";
 import { ZkProverClient, ZkWalletClient } from "@shinami/clients/sui";
 import { JWTVerifyGetKey, createRemoteJWKSet } from "jose";
@@ -22,21 +22,20 @@ export interface EpochInfo {
 
 export type CurrentEpochProvider =
   | (() => Promise<EpochInfo> | EpochInfo)
-  | SuiClient;
+  | ClientWithCoreApi;
 
 export async function getCurrentEpoch(
   provider: CurrentEpochProvider,
 ): Promise<EpochInfo> {
-  if (provider instanceof SuiClient) {
-    const { epoch, epochStartTimestampMs, epochDurationMs } =
-      await provider.getLatestSuiSystemState();
-    return {
-      epoch: Number(epoch),
-      epochStartTimestampMs: Number(epochStartTimestampMs),
-      epochDurationMs: Number(epochDurationMs),
-    };
+  if (typeof provider === "function") {
+    return await provider();
   }
-  return await provider();
+  const { systemState } = await provider.core.getCurrentSystemState();
+  return {
+    epoch: Number(systemState.epoch),
+    epochStartTimestampMs: Number(systemState.epochStartTimestampMs),
+    epochDurationMs: Number(systemState.parameters.epochDurationMs),
+  };
 }
 
 export interface SaltRequest {

--- a/packages/nextjs-zklogin/src/utils.ts
+++ b/packages/nextjs-zklogin/src/utils.ts
@@ -7,7 +7,7 @@ import { PublicKey, SIGNATURE_SCHEME_TO_FLAG } from "@mysten/sui/cryptography";
 import { Ed25519PublicKey } from "@mysten/sui/keypairs/ed25519";
 import { Secp256k1PublicKey } from "@mysten/sui/keypairs/secp256k1";
 import { Secp256r1PublicKey } from "@mysten/sui/keypairs/secp256r1";
-import { fromB64 } from "@mysten/sui/utils";
+import { fromBase64 } from "@mysten/sui/utils";
 
 export type HttpMethod =
   | "GET"
@@ -30,7 +30,7 @@ export function throwExpression(error: unknown): never {
 
 // This is the inverse of PublicKey.toSuiPublicKey()
 export function publicKeyFromBase64(b64: string): PublicKey {
-  const bytes = fromB64(b64);
+  const bytes = fromBase64(b64);
   if (bytes.length === 0) throw new Error("Empty key bytes");
 
   switch (bytes[0]) {

--- a/packages/nextjs-zklogin/tsconfig.cjs.json
+++ b/packages/nextjs-zklogin/tsconfig.cjs.json
@@ -1,1 +1,0 @@
-../../tsconfig.cjs.json

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,5 +5,5 @@
     "module": "commonjs",
     "moduleResolution": "node"
   },
-  "exclude": ["./src/sui"]
+  "exclude": ["./src/sui", "./src/aptos"]
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,5 +4,6 @@
     "outDir": "./dist/cjs",
     "module": "commonjs",
     "moduleResolution": "node"
-  }
+  },
+  "exclude": ["./src/sui"]
 }


### PR DESCRIPTION
Make our shinami typescript sdk aligned with Mysten's direction for their node api which is deprecating jsonrpc access in the near future, and adopting grpc and graphql moving forward. Also leverage v2 of Shinami's invisible wallet, which is migrated and grpc compliant.
- Upgrade dependency to mysten/sui@2.0.0
- sui@2.0.0 is [migrating](https://sdk.mystenlabs.com/sui/migrations/sui-2.0#esm-migration) to ESM only, so our sui client and nextjs-zklogin are doing the same.
- Our sui client now uses [ClientWithCoreApi](https://sdk.mystenlabs.com/sui/clients/core#clientwithcoreapi) which is transport agnostic. This means any upstream user of our client can plug in a SuiGrpcClient, SuiGraphqlClient, or even a SuiJsonRpcClient while it is still supported.
- Upgrade syntax changes in sui@2.0.0
- Upgrade aptos sdk dependency to 7.2.0